### PR TITLE
Remove junk character in comment

### DIFF
--- a/ssl-proxies/src/main/java/org/globus/gsi/proxy/ext/ProxyCertInfo.java
+++ b/ssl-proxies/src/main/java/org/globus/gsi/proxy/ext/ProxyCertInfo.java
@@ -96,7 +96,7 @@ public class ProxyCertInfo implements DEREncodable {
     }
 
     /**
-     * Returns an inÂstance of <code>ProxyCertInfo</code> from given object.
+     * Returns an instance of <code>ProxyCertInfo</code> from given object.
      *
      * @param obj the object to create the instance from.
      * @return <code>ProxyCertInfo</code> instance.


### PR DESCRIPTION
There is a junk character in a comment in ssl-proxies/src/main/java/org/globus/gsi/proxy/ext/ProxyCertInfo.java - this causes the compilation to fail:

[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:2.8.1:aggregate (default-cli) on project jglobus-all: An error has occurred in JavaDocs report generation:
[ERROR] Exit code: 1 - /home/ellert/rpmbuild/BUILD/jglobus-2.0.4/ssl-proxies/src/main/java/org/globus/gsi/proxy/ext/ProxyCertInfo.java:99: error: unmappable character for encoding UTF-8
[ERROR] \* Returns an in?stance of ProxyCertInfo from given object.
[ERROR] ^
[ERROR]
[ERROR] Command line was: /usr/lib/jvm/java-1.7.0-openjdk-1.7.0.3.x86_64/jre/../bin/javadoc @options @packages
