### PR TITLE
Fix potential thread leak

### DIFF
--- a/gridftp/src/main/java/org/globus/ftp/dc/TransferThreadManager.java
+++ b/gridftp/src/main/java/org/globus/ftp/dc/TransferThreadManager.java
@@ -297,14 +297,14 @@ public class TransferThreadManager {
        The thread will perform it when it's ready with other
        waiting tasks.
     **/
-    private void runTask(Task task) {
+    private synchronized void runTask(Task task) {
         if (taskThread == null) {
             taskThread = new TaskThread();
         }
         taskThread.runTask(task);
     }
 
-    public void stopTaskThread() {
+    public synchronized void stopTaskThread() {
         if (taskThread != null) {
             taskThread.stop();
             taskThread.join();


### PR DESCRIPTION
Those methods should be synchronized to avoid TaskThread being initialized multiple times in case of concurent access. It would lead to a thread leak.
