### PR TITLE
Remove ssl status ok check.

### DIFF
--- a/gss/src/main/java/org/globus/gsi/gssapi/GlobusGSSContextImpl.java
+++ b/gss/src/main/java/org/globus/gsi/gssapi/GlobusGSSContextImpl.java
@@ -780,12 +780,6 @@ public class GlobusGSSContextImpl implements ExtendedGSSContext {
 		 		new Exception("Unexpected BUFFER_UNDERFLOW;" +
                         " Handshaking status: " + sslEngine.getHandshakeStatus()));
                 }
-		if (result.getStatus() !=
-			SSLEngineResult.Status.OK) {
-               	throw new GlobusGSSException(GSSException.FAILURE,
-                                         GlobusGSSException.TOKEN_FAIL,
-                                         result.getStatus().toString());
-		}
               } while (inBBuff.hasRemaining());
 
 		return outBBuff;
@@ -829,12 +823,6 @@ public class GlobusGSSContextImpl implements ExtendedGSSContext {
 				SSLEngineResult.Status.BUFFER_UNDERFLOW) {
 			// More data needed from peer
 			break;
-		}
-		if (result.getStatus() !=
-			SSLEngineResult.Status.OK) {
-                	throw new GlobusGSSException(GSSException.FAILURE,
-                                             GlobusGSSException.TOKEN_FAIL,
-                                         result.getStatus().toString());
 		}
               } while (inBBuff.hasRemaining());
 		return outBBuff;


### PR DESCRIPTION
In the documenation:
http://docs.oracle.com/javase/1.5.0/docs/api/javax/net/ssl/SSLEngineResult.Status.html

I don't understand clearly that the state closed match an error. I cannot submit job on EGI WMS with that part of code enable, whereas everything work like a charm without this code.
