### PR TITLE
Use variables instead of hard coded versions.

### DIFF
--- a/container-test-utils/pom.xml
+++ b/container-test-utils/pom.xml
@@ -8,7 +8,6 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>container-test-utils</artifactId>
-  <version>2.0-SNAPSHOT</version>
   <name>Connector test utilities</name>
   <build>
     <pluginManagement>
@@ -51,12 +50,12 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jsse</artifactId>
-      <version>2.0-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>ssl-proxies</artifactId>
-      <version>2.0-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/gram/pom.xml
+++ b/gram/pom.xml
@@ -9,7 +9,6 @@
 	<groupId>org.jglobus</groupId>
 
 	<artifactId>gram</artifactId>
-	<version>2.0-SNAPSHOT</version>
 
 
 	<name>"Grid Resource Allocation and Management(GRAM)"</name>
@@ -54,17 +53,17 @@
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>ssl-proxies</artifactId>
-			<version>2.0-SNAPSHOT</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>gss</artifactId>
-			<version>2.0-SNAPSHOT</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>jsse</artifactId>
-			<version>2.0-SNAPSHOT</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/gridftp/pom.xml
+++ b/gridftp/pom.xml
@@ -10,7 +10,6 @@
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>gridftp</artifactId>
-	<version>2.0-SNAPSHOT</version>
 	<name>gridftp</name>
 
 	<build>
@@ -31,17 +30,17 @@
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>ssl-proxies</artifactId>
-			<version>2.0-SNAPSHOT</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>gss</artifactId>
-			<version>2.0-SNAPSHOT</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>jsse</artifactId>
-			<version>2.0-SNAPSHOT</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/gss/pom.xml
+++ b/gss/pom.xml
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>ssl-proxies</artifactId>
-      <version>2.0-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>commons-logging</groupId>
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jsse</artifactId>
-      <version>2.0-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
   <repositories>

--- a/io/pom.xml
+++ b/io/pom.xml
@@ -28,7 +28,7 @@
    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>ssl-proxies</artifactId>
-      <version>2.0-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
 
       <dependency>
@@ -68,25 +68,25 @@
       <dependency>
           <groupId>${project.groupId}</groupId>
           <artifactId>gridftp</artifactId>
-          <version>2.0-SNAPSHOT</version>
+          <version>${project.version}</version>
       </dependency>
       
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>gss</artifactId>
-      <version>2.0-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
       
    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jsse</artifactId>
-      <version>2.0-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
       
       <dependency>
           <groupId>${project.groupId}</groupId>
           <artifactId>gram</artifactId>
-          <version>2.0-SNAPSHOT</version>
+          <version>${project.version}</version>
       </dependency>
 
    </dependencies>

--- a/jsse/pom.xml
+++ b/jsse/pom.xml
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>ssl-proxies</artifactId>
-      <version>2.0-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
   <repositories>

--- a/ssl-proxies-tomcat/pom.xml
+++ b/ssl-proxies-tomcat/pom.xml
@@ -143,24 +143,24 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>ssl-proxies</artifactId>
-      <version>2.0-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>container-test-utils</artifactId>
-      <version>2.0-SNAPSHOT</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>test-utils</artifactId>
-      <version>2.0-SNAPSHOT</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jsse</artifactId>
-      <version>2.0-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/ssl-proxies/pom.xml
+++ b/ssl-proxies/pom.xml
@@ -65,7 +65,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>test-utils</artifactId>
-      <version>2.0-SNAPSHOT</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/test-utils/pom.xml
+++ b/test-utils/pom.xml
@@ -8,7 +8,6 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>test-utils</artifactId>
-  <version>2.0-SNAPSHOT</version>
   <name>Test Utilities</name>
   <build>
     <pluginManagement>


### PR DESCRIPTION
Using variables and inheriting version from the parent pom instead of hard coded versions makes it easier to use the maven release and versions plugins.
