### PR TITLE
validate ssl record length 

### DIFF
--- a/gss/src/main/java/org/globus/gsi/gssapi/SSLUtil.java
+++ b/gss/src/main/java/org/globus/gsi/gssapi/SSLUtil.java
@@ -140,6 +140,21 @@ public class SSLUtil {
     }
 
     /**
+     * Converts 2 bytes to a
+     * <code>unsigned short</code>.
+     *
+     * @param a byte 1
+     * @param b byte 2
+     * @return the <code>unsigned short</code> value of the 2 bytes
+     */
+    public static int toUnsignedShort(byte a, byte b) {
+        int n;
+        n = (a & 0xff) << 8;
+        n |= (b & 0xff);
+        return n;
+    }
+
+    /**
      * Converts 4 bytes to an <code>int</code> at 
      * the specified offset in the given byte array.
      *

--- a/gss/src/main/java/org/globus/gsi/gssapi/net/impl/GSIGssInputStream.java
+++ b/gss/src/main/java/org/globus/gsi/gssapi/net/impl/GSIGssInputStream.java
@@ -74,7 +74,7 @@ public class GSIGssInputStream extends GssInputStream {
             if (SSLUtil.read(this.in, this.header, 4, 1) < 0) {
                 return null;
             }
-            int len = SSLUtil.toShort(this.header[3], this.header[4]);
+            int len = SSLUtil.toUnsignedShort(this.header[3], this.header[4]);
             buf = new byte[this.header.length + len];
             System.arraycopy(this.header, 0, buf, 0, this.header.length);
             if (SSLUtil.read(this.in, buf, this.header.length, len) < 0) {
@@ -105,5 +105,4 @@ public class GSIGssInputStream extends GssInputStream {
         }
         return buf;
     }
-    
 }


### PR DESCRIPTION
in some cases we get proxy certificates which produces too big SSL records resulting to:

java.lang.NegativeArraySizeException: null
    at org.globus.gsi.gssapi.net.impl.GSIGssInputStream.readToken(GSIGssInputStream.java:79) ~[cog-jglobus-1.8.0-1.jar:na]
    at org.globus.gsi.gssapi.net.impl.GSIGssInputStream.readHandshakeToken(GSIGssInputStream.java:59) ~[cog-jglobus-1.8.0-1.jar:na]
    at org.globus.gsi.gssapi.net.impl.GSIGssSocket.readToken(GSIGssSocket.java:65) ~[cog-jglobus-1.8.0-1.jar:na]
    at org.globus.gsi.gssapi.net.GssSocket.authenticateServer(GssSocket.java:127) ~[cog-jglobus-1.8.0-1.jar:na]
    at org.globus.gsi.gssapi.net.GssSocket.startHandshake(GssSocket.java:147) ~[cog-jglobus-1.8.0-1.jar:na]

While problem observed with jglobus-1.8 it still exist in 2.0.
This simple fix validated record size and throws IOException allowed size is excided.
