### PR TITLE
Check if error occurs when waiting for completion.

### DIFF
--- a/gridftp/src/main/java/org/globus/ftp/vanilla/TransferState.java
+++ b/gridftp/src/main/java/org/globus/ftp/vanilla/TransferState.java
@@ -80,7 +80,7 @@ public class TransferState {
      * Blocks until the transfer is complete or 
      * the transfer fails.
      */
-    public void waitForEnd()
+    public synchronized void waitForEnd()
 	throws ServerException,
 	       ClientException,
 	       IOException {
@@ -98,7 +98,7 @@ public class TransferState {
      * Blocks until the transfer begins or
      * the transfer fails to start.
      */
-    public void waitForStart()
+    public synchronized void waitForStart()
 	throws ServerException,
 	       ClientException,
 	       IOException {


### PR DESCRIPTION
The implementation of the method does'nt take into account the case when an error occurs. The consequence is that after a while I get several threads blocked in this state:
   java.lang.Thread.State: WAITING (on object monitor)
        at java.lang.Object.wait(Native Method)
        at java.lang.Object.wait(Object.java:503)
        at org.globus.ftp.vanilla.TransferState.waitForEnd(TransferState.java:85)
        - locked <0x0000000720abd5f8> (a org.globus.ftp.vanilla.TransferState)
        at org.globus.io.streams.FTPOutputStream.close(FTPOutputStream.java:86)

This patch should fix it.
