### PR TITLE
Allow the exclusion of certain cipher types when establishing GSI connection

### DIFF
--- a/gss/src/main/java/org/globus/gsi/gssapi/GlobusGSSContextImpl.java
+++ b/gss/src/main/java/org/globus/gsi/gssapi/GlobusGSSContextImpl.java
@@ -259,6 +259,8 @@ public class GlobusGSSContextImpl implements ExtendedGSSContext {
     /** Limited peer credentials */
     protected Boolean peerLimited = null;
 
+    private String[] bannedCiphers = new String[0];
+
     /**
      * @param target expected target name. Can be null.
      * @param cred credential. Cannot be null. Might be anonymous.
@@ -1321,6 +1323,7 @@ done:      do {
                cs.addAll(Arrays.asList(this.sslEngine.getEnabledCipherSuites()));
             }
         }
+        cs.removeAll(Arrays.asList(bannedCiphers));
         String[] testSuite = new String[0];
         this.sslEngine.setEnabledCipherSuites(cs.toArray(testSuite));
         logger.debug("CIPHER SUITE IS: " + Arrays.toString(
@@ -2699,6 +2702,12 @@ done:      do {
         
         return null;
     }
+
+    public void setBannedCiphers(String[] ciphers) {
+        bannedCiphers = new String[ciphers.length];
+        System.arraycopy(ciphers, 0, bannedCiphers, 0, ciphers.length);
+    }
+
 
 
     // ==================================================================

--- a/ssl-proxies/src/main/java/org/gridforum/jgss/ExtendedGSSContext.java
+++ b/ssl-proxies/src/main/java/org/gridforum/jgss/ExtendedGSSContext.java
@@ -149,4 +149,10 @@ public interface ExtendedGSSContext extends GSSContext {
      *            <code>GSSException.FAILURE</code>
      */
     public Object inquireByOid(Oid oid) throws GSSException;
+
+    /**
+     * Specifies a list of ciphers that will not be used.
+     * @param ciphers The list of banned ciphers.
+     */
+    public void setBannedCiphers(String[] ciphers);
 }


### PR DESCRIPTION
There are several reasons for excluding a cipher algorithm: an algorithm may be too weak, too strong (for legal requirements) or broken/badly implemented.

This patch allows the application software to specify that one or more ciphers are not to be used.
