### PR TITLE
ssl-proxies: Fix CRL check race condition

### DIFF
--- a/ssl-proxies/src/main/java/org/globus/gsi/trustmanager/CRLChecker.java
+++ b/ssl-proxies/src/main/java/org/globus/gsi/trustmanager/CRLChecker.java
@@ -125,19 +125,19 @@ public class CRLChecker implements CertificateChecker {
             // validate CRL
             verifyCRL(caCert, crl);
 
-	    /* One would have thought that a CRL is immutable and thus
+            /* One would have thought that a CRL is immutable and thus
              * thread safe, however inside the ASN1 parse tree we find
              * LazyDERSequence. LazyDERSequence is parsed lazily and
              * does so in a non-thread safe manner. One may very well
              * classify this as a bouncy castle bug, but as a
              * workaround synchronizing on the CRL solves the problem.
              */
-	    synchronized (crl) {
-		if (crl.isRevoked(cert)) {
-		    throw new CertPathValidatorException(
-			"Certificate " + cert.getSubjectDN() + " has been revoked");
-		}
-	    }
+            synchronized (crl) {
+                if (crl.isRevoked(cert)) {
+                    throw new CertPathValidatorException(
+                        "Certificate " + cert.getSubjectDN() + " has been revoked");
+                }
+            }
         }
     }
 


### PR DESCRIPTION
JGlobus uses CRLs as if they were immutable objects, however when
using the Bouncy Castle provider, the ASN.1 parser uses lazy
evaluation internally, which means the X509CRL object is not
thread safe.

This bug was originally filed against JGlobus 1.8 in

http://lists.globus.org/pipermail/jglobus-dev/2009-December/000320.html

with a patch that we have used since in a dCache specific fork
of JGlobus 1.8.

This pull request represents a port of the patch to JGlobus 2. We haven't
used JGlobus 2 under high load situations and for long enough time to
know whether the bug can be reproduced, but I have no reason to believe
that JGlobus 2 should not suffer from the same problem.
