### PR TITLE
ssl-proxies: Performance and bug fixes in principal conversion utilities

### DIFF
--- a/ssl-proxies/src/test/java/org/globus/gsi/util/CertificateUtilTest.java
+++ b/ssl-proxies/src/test/java/org/globus/gsi/util/CertificateUtilTest.java
@@ -14,6 +14,8 @@
  */
 package org.globus.gsi.util;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import org.globus.gsi.testutils.FileSetupUtil;
@@ -29,6 +31,8 @@ import java.security.cert.X509Certificate;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import javax.security.auth.x500.X500Principal;
 
 /**
  * FILL ME
@@ -197,6 +201,74 @@ public class CertificateUtilTest {
         }
 
         assertTrue(worked);
+    }
+
+    @Test
+    public void testToGlobusIdForString()
+    {
+        String dn =
+            CertificateUtil.toGlobusID("DC=org, DC=DOEGrids, OU=Certificate Authorities, CN=DOEGrids CA 1",  true);
+        assertThat(dn, is("/DC=org/DC=DOEGrids/OU=Certificate Authorities/CN=DOEGrids CA 1"));
+    }
+
+    @Test
+    public void testToGlobusIdForReverseString()
+    {
+        String dn =
+            CertificateUtil.toGlobusID("CN=DOEGrids CA 1, OU=Certificate Authorities, DC=DOEGrids, DC=org",  false);
+        assertThat(dn, is("/DC=org/DC=DOEGrids/OU=Certificate Authorities/CN=DOEGrids CA 1"));
+    }
+
+    @Test
+    public void testToGlobusIdForX500Principal()
+    {
+        String dn = CertificateUtil.toGlobusID(
+            new X500Principal("CN=DOEGrids CA 1, OU=Certificate Authorities, DC=DOEGrids, DC=org"));
+        assertThat(dn, is("/DC=org/DC=DOEGrids/OU=Certificate Authorities/CN=DOEGrids CA 1"));
+    }
+
+    @Test
+    public void testToPrincipal()
+    {
+        X500Principal principal =
+            CertificateUtil.toPrincipal("/DC=org/DC=DOEGrids/OU=Certificate Authorities/CN=DOEGrids CA 1");
+        assertThat(principal, is(new X500Principal(
+            "CN=DOEGrids CA 1, OU=Certificate Authorities, DC=DOEGrids, DC=org")));
+    }
+
+    @Test
+    public void testToPrincipalWithSlashInAttribute()
+    {
+        X500Principal principal =
+            CertificateUtil.toPrincipal("/DC=org/DC=DOEGrids/OU=Certificate / Authorities/CN=DOEGrids CA 1");
+        assertThat(principal, is(new X500Principal(
+            "CN=DOEGrids CA 1, OU=Certificate / Authorities, DC=DOEGrids, DC=org")));
+    }
+
+    @Test
+    public void testToPrincipalWithEmptyAttribute()
+    {
+        X500Principal principal =
+            CertificateUtil.toPrincipal("/DC=org/DC=DOEGrids//CN=DOEGrids CA 1");
+        assertThat(principal, is(new X500Principal(
+            "CN=DOEGrids CA 1, DC=DOEGrids, DC=org")));
+    }
+
+    @Test
+    public void testToPrincipalWithEmptyString()
+    {
+        X500Principal principal =
+            CertificateUtil.toPrincipal("");
+        assertThat(principal, is(new X500Principal("")));
+    }
+
+    @Test
+    public void testToPrincipalWithWhiteSpace()
+    {
+        X500Principal principal =
+            CertificateUtil.toPrincipal(" /DC=org/ DC=DOEGrids/OU=Certificate Authorities / CN=DOEGrids CA 1   ");
+        assertThat(principal, is(new X500Principal(
+            "CN=DOEGrids CA 1, OU=Certificate Authorities, DC=DOEGrids, DC=org")));
     }
 
     @After


### PR DESCRIPTION
The CertificateUtil class provides utilities for converting between
Globus DN notation and other string representations.

This patch fixes an O(n^2) problem in toGlobusId() caused by repeatedly
prepending a string to a StringBuffer, thus causing a growing string
to be copied internally.

The patch optimizes toPrincipal() by avoiding the rather expensive
LinkedList and replacing it with an ArrayDeque preallocated to the
correct size.

The patch also replaces the use of StringBuffer with the more efficient
StringBuilder class.

The patch fixes a bug in toPrincipal() in which white space around a
slash appearing inside an attribute value was stripped.

The patch adds unit tests for all three methods.
