### PR TITLE
remove useless method TrustedCertificates.refresh()

### DIFF
--- a/ssl-proxies/src/main/java/org/globus/gsi/TrustedCertificates.java
+++ b/ssl-proxies/src/main/java/org/globus/gsi/TrustedCertificates.java
@@ -213,10 +213,6 @@ public class TrustedCertificates implements Serializable {
         }
     }
 
-    public void refresh() {
-        reload(null);
-    }
-
     public synchronized void reload(String locations) {
         if (locations == null) {
             return;
@@ -354,7 +350,7 @@ public class TrustedCertificates implements Serializable {
         if (trustedCertificates == null) {
             trustedCertificates = new DefaultTrustedCertificates();
         }
-        trustedCertificates.refresh();
+
         return trustedCertificates;
     }
     


### PR DESCRIPTION
refresh() method is a NOP:

```
public void refresh() {
    reload(null);
}

public synchronized void reload(String locations) {
    if (locations == null) {
        return;
    }
```

....
