### PR TITLE
Update GlobusGSSException to avoid boring messages.

### DIFF
--- a/gss/src/main/java/org/globus/gsi/gssapi/GlobusGSSException.java
+++ b/gss/src/main/java/org/globus/gsi/gssapi/GlobusGSSException.java
@@ -26,6 +26,8 @@ import javax.net.ssl.SSLException;
 
 public class GlobusGSSException extends GSSException {
 
+    private static final long serialVersionUID = 1366868883920091438L;
+    
     public static final int
 	PROXY_VIOLATION = 5,
 	BAD_ARGUMENT = 7,


### PR DESCRIPTION
Quite often, a GlobusGSSException is used to wrap an existing Exception
where is adds no additional meaning.  Often this is due to catching
Exception but the signature of the method allows only GSSException to
be thrown, which is a bad code-smell.

The result of this problem is Exception messages with many chained
"Failure unspecified at GSS-API level" messages.  Here is an example:

24 Apr 2013 07:31:17 (SRM-vedrfolnir) [] org.globus.common.ChainedIOException: Authentication failed [Caused by: Failure unspecified at GSS-API level [Caused by: Failure unspecified at GSS-API level [Caused by: sun.security.pkcs11.wrapper.PKCS11Exception: CKR_DOMAIN_PARAMS_INVALID]]]

As a work-around, this patch skips over these semantically-null
messages: if the message would be "Failure unspecified at
GSS-API level" and an exception has been logged as the cause (printed as "Caused by...") then only the message from the cause is printed.

With this change, the above exception becomes:

pr 2013 07:37:21 (SRM-vedrfolnir) [] org.globus.common.ChainedIOException: Authentication failed [Caused by: sun.security.pkcs11.wrapper.PKCS11Exception: CKR_DOMAIN_PARAMS_INVALID]

I consider this patch a quick-fix work-around as the real solution would be to modify code so it refrains from wrapping exceptions in situations where it isn't needed and no additional context is provided.  This will probably be part of a complete rewrite of GlobusGSSException (perhaps dropping the class altogether) and how it is being used.

Please also merge this to the v2.0 branch for the next 2.0.x release.
