### PR TITLE
Add better error message when certificate chain verification fails

### DIFF
--- a/ssl-proxies/src/main/java/org/globus/gsi/trustmanager/PKITrustManager.java
+++ b/ssl-proxies/src/main/java/org/globus/gsi/trustmanager/PKITrustManager.java
@@ -93,9 +93,9 @@ public class PKITrustManager implements X509TrustManager {
         try {
             this.result = this.validator.engineValidate(certPath, parameters);
         } catch (CertPathValidatorException exception) {
-            throw new CertificateException("Pathvalidation failed", exception);
+            throw new CertificateException("Path validation failed: " + exception.getMessage(), exception);
         } catch (InvalidAlgorithmParameterException exception) {
-            throw new CertificateException("Pathvalidation failed", exception);
+            throw new CertificateException("Path validation failed: " + exception.getMessage(), exception);
         }
     }
 


### PR DESCRIPTION
The trust manager class PKITrustManager contains two near identity methods for checking whether the identity remote party is trusted, either as a server or as a client.  The message when reporting a problem with a remote server includes the cause whereas problems with a remote client are described enigmatically as just "Pathvalidation failed" [sic].

This patch fixes this problem by including the cause in the message, so the admin has some chance of fixing it.

Please also merge into v2.0 branch for next 2.0.x release.
