### PR TITLE
Add better error message when certificate chain verification fails

### DIFF
--- a/ssl-proxies/src/main/java/org/globus/gsi/trustmanager/PKITrustManager.java
+++ b/ssl-proxies/src/main/java/org/globus/gsi/trustmanager/PKITrustManager.java
@@ -93,9 +93,9 @@ public class PKITrustManager implements X509TrustManager {
         try {
             this.result = this.validator.engineValidate(certPath, parameters);
         } catch (CertPathValidatorException exception) {
-            throw new CertificateException("Pathvalidation failed", exception);
+            throw new CertificateException("Path validation failed: " + exception.getMessage(), exception);
         } catch (InvalidAlgorithmParameterException exception) {
-            throw new CertificateException("Pathvalidation failed", exception);
+            throw new CertificateException("Path validation failed: " + exception.getMessage(), exception);
         }
     }
 


### PR DESCRIPTION
v2.0 version of the patch already committed to master.  The patch is actually identical.
