### PR TITLE
Fix GlobusGSSContextTest

### DIFF
--- a/gss/src/test/java/org/globus/gsi/gssapi/test/GlobusGSSContextTest.java
+++ b/gss/src/test/java/org/globus/gsi/gssapi/test/GlobusGSSContextTest.java
@@ -72,6 +72,7 @@ public class GlobusGSSContextTest extends TestCase {
             serverContext = null;
         }
 
+        X509Credential.setDefaultCredential(null);
 
 	GSSManager manager = getGSSManager();
 
@@ -86,7 +87,6 @@ public class GlobusGSSContextTest extends TestCase {
 					      GSSConstants.MECH_OID,
 					      null, 
 					      GSSContext.DEFAULT_LIFETIME);
-
     }
 
     protected void tearDown() throws Exception {


### PR DESCRIPTION
The GlobusGSSContextTest relies on having a credential, which then relies
on X509Credential class not having a cached copy of such a credential.
However, it does not ensure there is no such cached credential.

Since multiple tests (and test-suites) are run within the same JVM
instance, the effect is that, if another test-suite caches a
(deliberately) invalid, self-signed certificate then this cached
copy is returned instead of the expected certificate.

This patch fixes this problem by ensuring the cache is cleared.  It
introduces a (negliable) overhead as the cache is flushed between
tests; however, the additional robustness justifies this cost.

Please commit to v2.0 and cherry-pick to master
