### PR TITLE
Improve RFC 3820 compliance of key usage check

### DIFF
--- a/ssl-proxies/src/main/java/org/globus/gsi/trustmanager/X509ProxyCertPathValidator.java
+++ b/ssl-proxies/src/main/java/org/globus/gsi/trustmanager/X509ProxyCertPathValidator.java
@@ -14,13 +14,21 @@
  */
 package org.globus.gsi.trustmanager;
 
-import org.globus.gsi.util.CertificateUtil;
-import org.globus.gsi.util.ProxyCertificateUtil;
-
+import org.bouncycastle.asn1.DERObjectIdentifier;
+import org.bouncycastle.asn1.x509.BasicConstraints;
+import org.bouncycastle.asn1.x509.TBSCertificateStructure;
+import org.bouncycastle.asn1.x509.X509Extension;
+import org.bouncycastle.asn1.x509.X509Extensions;
+import org.globus.gsi.GSIConstants;
 import org.globus.gsi.X509ProxyCertPathParameters;
 import org.globus.gsi.X509ProxyCertPathValidatorResult;
-
 import org.globus.gsi.provider.SigningPolicyStore;
+import org.globus.gsi.proxy.ProxyPolicyHandler;
+import org.globus.gsi.proxy.ext.ProxyCertInfo;
+import org.globus.gsi.proxy.ext.ProxyPolicy;
+import org.globus.gsi.util.CertificateUtil;
+import org.globus.gsi.util.KeyUsage;
+import org.globus.gsi.util.ProxyCertificateUtil;
 
 import java.io.IOException;
 import java.security.InvalidAlgorithmParameterException;
@@ -35,19 +43,10 @@ import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Map;
-
-import org.bouncycastle.asn1.DERObjectIdentifier;
-import org.bouncycastle.asn1.x509.BasicConstraints;
-import org.bouncycastle.asn1.x509.TBSCertificateStructure;
-import org.bouncycastle.asn1.x509.X509Extension;
-import org.bouncycastle.asn1.x509.X509Extensions;
-import org.globus.gsi.GSIConstants;
-import org.globus.gsi.proxy.ext.ProxyCertInfo;
-import org.globus.gsi.proxy.ext.ProxyPolicy;
-import org.globus.gsi.proxy.ProxyPolicyHandler;
 
 /**
  * Implementation of the CertPathValidatorSpi and the logic for X.509 Proxy Path Validation.
@@ -422,9 +421,8 @@ public class X509ProxyCertPathValidator extends CertPathValidatorSpi {
     protected void checkKeyUsage(TBSCertificateStructure issuer)
             throws CertPathValidatorException, IOException {
 
-        boolean[] issuerKeyUsage = CertificateUtil.getKeyUsage(issuer);
-
-        if (issuerKeyUsage != null && issuerKeyUsage.length > 0 && !issuerKeyUsage[CertificateUtil.KEY_CERTSIGN]) {
+        EnumSet<KeyUsage> issuerKeyUsage = CertificateUtil.getKeyUsage(issuer);
+        if (!issuerKeyUsage.contains(KeyUsage.KEY_CERTSIGN)) {
             throw new CertPathValidatorException("Certificate " + issuer.getSubject() + " violated key usage policy.");
         }
     }
@@ -511,10 +509,9 @@ public class X509ProxyCertPathValidator extends CertPathValidatorSpi {
     }
 
     private void checkKeyUsage(TBSCertificateStructure issuer, X509Extension proxyExtension) throws IOException, CertPathValidatorException {
-        boolean[] keyUsage =
-                CertificateUtil.getKeyUsage(proxyExtension);
+        EnumSet<KeyUsage> keyUsage = CertificateUtil.getKeyUsage(proxyExtension);
         // these must not be asserted
-        if (keyUsage[CertificateUtil.NON_REPUDIATION] || keyUsage[CertificateUtil.KEY_CERTSIGN]) {
+        if (keyUsage.contains(KeyUsage.NON_REPUDIATION) || keyUsage.contains(KeyUsage.KEY_CERTSIGN)) {
             throw new CertPathValidatorException("Proxy violation: Key usage is asserted.");
         }
     }

--- a/ssl-proxies/src/main/java/org/globus/gsi/util/KeyUsage.java
+++ b/ssl-proxies/src/main/java/org/globus/gsi/util/KeyUsage.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2013 NORDUnet A/S
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS,WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+package org.globus.gsi.util;
+
+import org.bouncycastle.asn1.DERBitString;
+
+public enum KeyUsage
+{
+    DIGITAL_SIGNATURE(0),
+    NON_REPUDIATION(1),
+    KEY_ENCIPHERMENT(2),
+    DATA_ENCIPHERMENT(3),
+    KEY_AGREEMENT(4),
+    KEY_CERTSIGN(5),
+    CRL_SIGN(6),
+    ENCIPHER_ONLY(7),
+    DECIPHER_ONLY(8);
+
+    private int bit;
+
+    private KeyUsage(int bit) {
+        this.bit = bit;
+    }
+
+    public boolean isSet(DERBitString bits) {
+        byte[] bytes = bits.getBytes();
+        int length = (bytes.length * 8) - bits.getPadBits();
+        return (bit < length && ((bytes[bit / 8] & (0x80 >>> (bit % 8))) != 0));
+    }
+}


### PR DESCRIPTION
I kindly ask that 6840a343ad3c7a1766a0ed8f3dc2a469219d86e7 is merged into the 2.0 branch too.

The second commit simply cleans up the representation of key usage information.
