### PR TITLE
ssl-proxies: Improve RFC 3820 compliance of key usage check

### DIFF
--- a/ssl-proxies/src/main/java/org/globus/gsi/trustmanager/X509ProxyCertPathValidator.java
+++ b/ssl-proxies/src/main/java/org/globus/gsi/trustmanager/X509ProxyCertPathValidator.java
@@ -517,18 +517,6 @@ public class X509ProxyCertPathValidator extends CertPathValidatorSpi {
         if (keyUsage[CertificateUtil.NON_REPUDIATION] || keyUsage[CertificateUtil.KEY_CERTSIGN]) {
             throw new CertPathValidatorException("Proxy violation: Key usage is asserted.");
         }
-        boolean[] issuerKeyUsage = CertificateUtil.getKeyUsage(issuer);
-        if (issuerKeyUsage.length > 0) {
-            for (int i = 0; i < CertificateUtil.DEFAULT_USAGE_LENGTH; i++) {
-                if (i == CertificateUtil.NON_REPUDIATION || i == CertificateUtil.KEY_CERTSIGN) {
-                    continue;
-                }
-                if (!issuerKeyUsage[i] && keyUsage[i]) {
-                    throw new CertPathValidatorException(
-                            "Proxy violation: Issuer key usage is incorrect");
-                }
-            }
-        }
     }
 
     private void checkExtension(DERObjectIdentifier oid, X509Extension proxyExtension, X509Extension proxyKeyUsage) throws CertPathValidatorException {


### PR DESCRIPTION
Each certificate in a certificate chain can have a key usage field. The existing JGlobus code checks that each proxy certificate does not ave more key usages than the issuing certificate. This seems like a sensible check, however it conflicts with the algorithm described in RFC 3820.

The RFC states that all key usage (and extended key usage) extensions of all proxy certificates and the EEC must be collected in a list and the effective key usage computed by the intersection of all extensions:
-  If a certificate is a proxy certificate with a policy other than
    id-ppl-independent, the effective key usage and extended key usage
    functionality of the proxy certificate is the intersection of the
    functionality of those extensions in the proxy certificate and the
    effective key usage functionality of the proxy issuer.

Since JGlobus does not actually utilize the key usage, this patch simply removes the faulty check. The effective key usage is not computed.

We have observed real-world proxy certificates that failed with the existing check in JGlobus 2, even though they are valid proxies according to the RFC. These proxies also work with JGlobus 1.
