### PR TITLE
ssl-proxies: Fix path validator when cert is lacking key usage extensions

### DIFF
--- a/ssl-proxies/src/main/java/org/globus/gsi/trustmanager/X509ProxyCertPathValidator.java
+++ b/ssl-proxies/src/main/java/org/globus/gsi/trustmanager/X509ProxyCertPathValidator.java
@@ -424,7 +424,7 @@ public class X509ProxyCertPathValidator extends CertPathValidatorSpi {
             throws CertPathValidatorException, IOException {
 
         EnumSet<KeyUsage> issuerKeyUsage = CertificateUtil.getKeyUsage(issuer);
-        if (!issuerKeyUsage.contains(KeyUsage.KEY_CERTSIGN)) {
+        if (issuerKeyUsage != null && !issuerKeyUsage.contains(KeyUsage.KEY_CERTSIGN)) {
             throw new CertPathValidatorException("Certificate " + issuer.getSubject() + " violated key usage policy.");
         }
     }

--- a/ssl-proxies/src/main/java/org/globus/gsi/util/CertificateUtil.java
+++ b/ssl-proxies/src/main/java/org/globus/gsi/util/CertificateUtil.java
@@ -430,11 +430,11 @@ public final class CertificateUtil {
             throws IOException {
         X509Extensions extensions = crt.getExtensions();
         if (extensions == null) {
-            return EnumSet.noneOf(KeyUsage.class);
+            return null;
         }
         X509Extension extension =
                 extensions.getExtension(X509Extensions.KeyUsage);
-        return (extension != null) ? getKeyUsage(extension) : EnumSet.noneOf(KeyUsage.class);
+        return (extension != null) ? getKeyUsage(extension) : null;
     }
 
     /**


### PR DESCRIPTION
270e41c6b59f5f113edd18cbad71956444f2090c introduced an enum to represent
key usage bits. The patch broke the key usage check for non-proxy certs
in that it did not deal correctly with the absence of the extension.
