### PR TITLE
ssl-proxies: Fix several race conditions

### DIFF
--- a/gss/src/main/java/org/globus/gsi/gssapi/GlobusGSSContextImpl.java
+++ b/gss/src/main/java/org/globus/gsi/gssapi/GlobusGSSContextImpl.java
@@ -361,7 +361,7 @@ public class GlobusGSSContextImpl implements ExtendedGSSContext {
     }
 */
 
-    private static KeyStore getTrustStore(String caCertsLocation) throws  GeneralSecurityException, IOException
+    private static synchronized KeyStore getTrustStore(String caCertsLocation) throws  GeneralSecurityException, IOException
     {
         if(GlobusGSSContextImpl.ms_trustStore != null)
             return GlobusGSSContextImpl.ms_trustStore;
@@ -375,7 +375,7 @@ public class GlobusGSSContextImpl implements ExtendedGSSContext {
         return keyStore;
     }
     
-    private static CertStore getCRLStore(String caCertsLocation) throws GeneralSecurityException, NoSuchAlgorithmException
+    private static synchronized CertStore getCRLStore(String caCertsLocation) throws GeneralSecurityException, NoSuchAlgorithmException
     {
         if(GlobusGSSContextImpl.ms_crlStore != null)
             return GlobusGSSContextImpl.ms_crlStore;
@@ -388,7 +388,7 @@ public class GlobusGSSContextImpl implements ExtendedGSSContext {
         return crlStore;
     }
     
-    private static ResourceSigningPolicyStore getSigPolStore(String caCertsLocation) throws GeneralSecurityException
+    private static synchronized ResourceSigningPolicyStore getSigPolStore(String caCertsLocation) throws GeneralSecurityException
     {
         if(GlobusGSSContextImpl.ms_sigPolStore != null)
             return GlobusGSSContextImpl.ms_sigPolStore;

--- a/ssl-proxies/src/main/java/org/globus/gsi/util/CertificateIOUtil.java
+++ b/ssl-proxies/src/main/java/org/globus/gsi/util/CertificateIOUtil.java
@@ -103,7 +103,7 @@ public final class CertificateIOUtil {
         }
     }
 
-    private static String hash(byte[] data) {
+    private static synchronized String hash(byte[] data) {
         init();
         if (md5 == null) {
             return null;


### PR DESCRIPTION
In particular the race in CertificateIOUtil has caused signing policies
be registered with the wrong hash. This in turn causes certificates
from the corresponding CA to be rejected.

(cherry picked from commit 1a0952b493a62e30dfe84937ec76cca00a8b6095)
