### PR TITLE
Fixing issue 105. Fixing SSL version issue. 

### DIFF
--- a/gram/pom.xml
+++ b/gram/pom.xml
@@ -21,6 +21,11 @@
 			<artifactId>gss</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>ssl-proxies</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>

--- a/gram/src/main/java/org/globus/gram/GramJob.java
+++ b/gram/src/main/java/org/globus/gram/GramJob.java
@@ -227,6 +227,9 @@ public class GramJob implements GRAMConstants {
     /**
      * Submits a job to the specified gatekeeper as an
      * interactive job. Performs limited delegation.
+     * Communication with Gram will be performed using both
+     * "TLSv1", "SSLv3" protocols. i.e forceSSLV3ForGram is set to <code>false</code>.
+     * @see org.globus.gsi.gssapi.GlobusGSSContextImpl
      * 
      * @param contact the resource manager contact.
      * The contact can be specified in number of ways for 1.1.3 gatekeepers:
@@ -252,10 +255,48 @@ public class GramJob implements GRAMConstants {
 	throws GramException, GSSException {
 	Gram.request(contact, this, false);
     }
+
+    /**
+     * Submits a job to the specified gatekeeper as an
+     * interactive job. Performs limited delegation.
+     *
+     * @param forceSSLV3ForGram Communication with GRAM servers will currently only succeed with
+     *                          SSLv3 and a narrow set of cipher suites. So, applications attempting
+     *                          communication with GRAM must set this to true to force the GSSAPI layer to constrain
+     *                          JSSE to SSLv3 and SSL_RSA_WITH_3DES_EDE_CBC_SHA when confidentiality is requested via
+     *                          requestConf() and SSL_RSA_WITH_NULL_SHA otherwise.
+     *                          Also see gss/src/main/java/org/globus/gsi/gssapi/Java_GSI_GSSAPI.html.
+     * @param contact the resource manager contact.
+     * The contact can be specified in number of ways for 1.1.3 gatekeepers:
+     * <br>
+     * host <br>
+     * host:port <br>
+     * host:port/service <br>
+     * host/service <br>
+     * host:/service <br>
+     * host::subject <br>
+     * host:port:subject <br>
+     * host/service:subject <br>
+     * host:/service:subject <br>
+     * host:port/service:subject <br>
+     * For 1.1.2 gatekeepers full contact string must be specifed.
+     *
+     * @throws GramException
+     *         if error occurs during job submission.
+     * @throws GSSException
+     *         if user credentials are invalid.
+     */
+    public void request(boolean forceSSLV3ForGram, String contact)
+            throws GramException, GSSException {
+        Gram.request(contact, this, false, true, forceSSLV3ForGram);
+    }
     
     /**
      * Submits a job to the specified gatekeeper either as
      * an interactive or batch job. Performs limited delegation.
+     * Communication with Gram will be performed using both
+     * "TLSv1", "SSLv3" protocols. i.e forceSSLV3ForGram is set to <code>false</code>.
+     * @see org.globus.gsi.gssapi.GlobusGSSContextImpl
      * 
      * @param contact 
      *        the resource manager contact.
@@ -276,8 +317,39 @@ public class GramJob implements GRAMConstants {
 
     /**
      * Submits a job to the specified gatekeeper either as
+     * an interactive or batch job. Performs limited delegation.
+     *
+     * @param forceSSLV3ForGram Communication with GRAM servers will currently only succeed with
+     *                          SSLv3 and a narrow set of cipher suites. So, applications attempting
+     *                          communication with GRAM must set this to true to force the GSSAPI layer to constrain
+     *                          JSSE to SSLv3 and SSL_RSA_WITH_3DES_EDE_CBC_SHA when confidentiality is requested via
+     *                          requestConf() and SSL_RSA_WITH_NULL_SHA otherwise.
+     *                          Also see gss/src/main/java/org/globus/gsi/gssapi/Java_GSI_GSSAPI.html.
+     * @param contact
+     *        the resource manager contact.
+     * @param batch
+     *        specifies if the job should be submitted as
+     *        a batch job.
+     * @throws GramException
+     *         if error occurs during job submission.
+     * @throws GSSException
+     *         if user credentials are invalid.
+     * @see #request(String) for detailed resource manager
+     *       contact specification.
+     */
+    public void request(boolean forceSSLV3ForGram, String contact, boolean batch)
+            throws GramException, GSSException {
+        Gram.request(contact, this, batch, true, forceSSLV3ForGram);
+    }
+
+    /**
+     * Submits a job to the specified gatekeeper either as
      * an interactive or batch job. It can perform limited
      * or full delegation.
+     * Communication with Gram will be performed using both
+     * "TLSv1", "SSLv3" protocols. i.e forceSSLV3ForGram is set to <code>false</code>.
+     * @see org.globus.gsi.gssapi.GlobusGSSContextImpl
+     *
      *
      * @param contact
      *        the resource manager contact. 
@@ -299,6 +371,39 @@ public class GramJob implements GRAMConstants {
 			boolean limitedDelegation)
 	throws GramException, GSSException {
 	Gram.request(contact, this, batch, limitedDelegation);
+    }
+
+    /**
+     * Submits a job to the specified gatekeeper either as
+     * an interactive or batch job. It can perform limited
+     * or full delegation.
+     *
+     * @param forceSSLV3ForGram Communication with GRAM servers will currently only succeed with
+     *                          SSLv3 and a narrow set of cipher suites. So, applications attempting
+     *                          communication with GRAM must set this to true to force the GSSAPI layer to constrain
+     *                          JSSE to SSLv3 and SSL_RSA_WITH_3DES_EDE_CBC_SHA when confidentiality is requested via
+     *                          requestConf() and SSL_RSA_WITH_NULL_SHA otherwise.
+     *                          Also see gss/src/main/java/org/globus/gsi/gssapi/Java_GSI_GSSAPI.html.
+     * @param contact
+     *        the resource manager contact.
+     * @param batch
+     *        specifies if the job should be submitted as
+     *        a batch job.
+     * @param limitedDelegation
+     *        true for limited delegation, false for
+     *        full delegation.
+     * @throws GramException
+     *         if error occurs during job submission.
+     * @throws GSSException
+     *         if user credentials are invalid.
+     * @see #request(String) for detailed resource manager
+     *       contact specification.
+     */
+    public void request(boolean forceSSLV3ForGram, String contact,
+                        boolean batch,
+                        boolean limitedDelegation)
+            throws GramException, GSSException {
+        Gram.request(contact, this, batch, limitedDelegation, forceSSLV3ForGram);
     }
 
     /**

--- a/gram/src/test/java/org/globus/gram/tests/GramTest.java
+++ b/gram/src/test/java/org/globus/gram/tests/GramTest.java
@@ -37,6 +37,8 @@ public class GramTest extends TestCase {
 
     private static final int TIMEOUT = 1000*60*2;
 
+    private static boolean ENFORCE_GRAM_SSL_V3 = false;
+
     private static Log logger = 
 	LogFactory.getLog(GramTest.class.getName());
 
@@ -49,6 +51,9 @@ public class GramTest extends TestCase {
 	try {
 	    System.out.println("Current directory = "+ System.getProperty("user.dir"));
 		util = new TestUtil(CONFIG);
+
+        ENFORCE_GRAM_SSL_V3 = Boolean.parseBoolean(util.get("enforce.gram.ssl_v3"));
+
 	} catch (Exception e) {
 	    e.printStackTrace();
 	    System.exit(-1);
@@ -78,21 +83,21 @@ public class GramTest extends TestCase {
     public void testActiveJobs() throws Exception {
 
         GramJob job1 = new GramJob(util.get("job.long"));
-	job1.request(util.get("job.long.contact"));
+        job1.request(ENFORCE_GRAM_SSL_V3, util.get("job.long.contact"));
 
         GramJob job2 = new GramJob(util.get("job.long"));
-	job2.request(util.get("job.long.contact"));
+        job2.request(ENFORCE_GRAM_SSL_V3, util.get("job.long.contact"));
 
         assertEquals(2, Gram.getActiveJobs());
 
         int i = 0;
-	while ( Gram.getActiveJobs() != 0 ) {
-            Thread.sleep(2000); 
+        while (Gram.getActiveJobs() != 0) {
+            Thread.sleep(2000);
             i++;
             if (i == 40) {
                 fail("getActiveJob() did not reported 0 jobs");
             }
-	}
+        }
     }
 
     public void testJobStatusPoll() throws Exception {
@@ -101,7 +106,7 @@ public class GramTest extends TestCase {
 	    GramJob(util.get("job.long"));
 	
 	logger.debug("submitting job in batch mode...");
-	job.request(util.get("job.long.contact"), true);
+	job.request(ENFORCE_GRAM_SSL_V3, util.get("job.long.contact"), true);
 	logger.debug("job submitted: " + job.getIDAsString());
 
 	String status = null;
@@ -140,7 +145,7 @@ public class GramTest extends TestCase {
 	    GramJob(util.get("job.long"));
 	
 	logger.debug("submitting job in batch mode...");
-	job.request(util.get("job.long.contact"), true);
+	job.request(ENFORCE_GRAM_SSL_V3, util.get("job.long.contact"), true);
 	logger.debug("job submitted: " + job.getIDAsString());
 
 	DoneStatusListener listener = new DoneStatusListener();
@@ -164,7 +169,7 @@ public class GramTest extends TestCase {
 	job.addListener(listener);
 	
 	logger.debug("submitting job in interactive mode...");
-	job.request(util.get("job.long.contact"));
+	job.request(ENFORCE_GRAM_SSL_V3, util.get("job.long.contact"));
 	logger.debug("job submitted: " + job.getIDAsString());
 
 	Thread.sleep(5000);
@@ -186,7 +191,7 @@ public class GramTest extends TestCase {
 	job.addListener(listener);
 	
 	logger.debug("submitting job in interactive mode...");
-	job.request(util.get("job.long.contact"));
+	job.request(ENFORCE_GRAM_SSL_V3, util.get("job.long.contact"));
 	logger.debug("job submitted: " + job.getIDAsString());
 	
 	if (!listener.waitFor(TIMEOUT)) {
@@ -208,7 +213,7 @@ public class GramTest extends TestCase {
     public void testBadParameter() throws Exception {
 	GramJob job = new GramJob("&(argument=12)");
 	try {
-	    job.request(util.get("job.long.contact"));
+	    job.request(ENFORCE_GRAM_SSL_V3, util.get("job.long.contact"));
 	} catch (GramException e) {
 	    if (e.getErrorCode() != GramException.PARAMETER_NOT_SUPPORTED) {
 		e.printStackTrace();
@@ -224,7 +229,7 @@ public class GramTest extends TestCase {
 	job.addListener(listener);
 
 	try {
-	    job.request(util.get("job.long.contact"));
+	    job.request(ENFORCE_GRAM_SSL_V3, util.get("job.long.contact"));
 	} catch (GramException e) {
 	    if (e.getErrorCode() != GramException.EXECUTABLE_NOT_FOUND) {
 		e.printStackTrace();
@@ -273,7 +278,7 @@ public class GramTest extends TestCase {
 
 	    GramJob job = new GramJob(rsl.toString());
 	    job.addListener(listener);
-	    job.request(util.get("job.long.contact"));
+	    job.request(ENFORCE_GRAM_SSL_V3, util.get("job.long.contact"));
 
 	    if (!listener.waitFor(TIMEOUT)) {
 		fail("Did not get DONE notification");
@@ -357,7 +362,7 @@ public class GramTest extends TestCase {
         GramJob job = new GramJob(util.get("job.long") + "(twoPhase=yes)");
 
         try {
-            job.request(util.get("job.long.contact"));
+            job.request(ENFORCE_GRAM_SSL_V3, util.get("job.long.contact"));
 
             fail("Did not throw expected exception");
 	} catch(WaitingForCommitException e) {
@@ -394,7 +399,7 @@ public class GramTest extends TestCase {
         GramJob job = new GramJob(util.get("job.long") + "(twoPhase=yes)");
         
         try {
-            job.request(util.get("job.long.contact"));
+            job.request(ENFORCE_GRAM_SSL_V3, util.get("job.long.contact"));
 	} catch(WaitingForCommitException e) {
             logger.debug("Two phase commit: sending COMMIT_EXTEND signal");
             

--- a/gram/src/test/resources/test.properties
+++ b/gram/src/test/resources/test.properties
@@ -1,4 +1,6 @@
-job.long=&(executable=/bin/sleep)(arguments=35)
-job.long.contact=ubuntu:50000:/O=Grid/OU=GlobusTest/OU=simpleCA-ubuntu/CN=Vijay Anand
+job.long=&( hostCount = "1" )( queue = "normal" )( project = "TG-STA110014S" )( jobtype = "single" )( arguments = "30" )( proxy_timeout = "1" )( count = "1" )( executable = "/bin/sleep" )( maxwalltime = "1" )
+job.long.contact=trestles-login2.sdsc.edu:2119/jobmanager-pbstest2
 stdin.exe=/bin/cat
-stdin.file=/home/vijay/archive/CHANGES.TXT
+stdin.file=Users/thejaka/test.txt
+enforce.gram.ssl_v3=true
+


### PR DESCRIPTION
This pulls request contains the fix for issue 105.
When communicating with servers like trestles, stampede, lonestar we need to use SSLv3. But by default gram uses TLS and SSL as enabled protocols. Therefore added a flag to enable SSLv3 through API.

According to documentation gss/src/main/java/org/globus/gsi/gssapi/Java_GSI_GSSAPI.html [1] we need to enable SSLv3 using context object.

Please review and let me know if further changes needed to be made.

Thanks
Amila

[1] https://github.com/jglobus/JGlobus/blob/v2.0.6/gss/src/main/java/org/globus/gsi/gssapi/Java_GSI_GSSAPI.html
