### PR TITLE
Upgrade the dependency on Bouncy Castle (1.46 -> 1.49)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,8 +138,8 @@
 			</dependency>
 			<dependency>
 				<groupId>org.bouncycastle</groupId>
-				<artifactId>bcprov-jdk16</artifactId>
-				<version>1.46</version>
+				<artifactId>bcprov-jdk15on</artifactId>
+				<version>1.49</version>
 			</dependency>
 			<dependency>
 				<groupId>commons-io</groupId>

--- a/ssl-proxies/pom.xml
+++ b/ssl-proxies/pom.xml
@@ -22,7 +22,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
-			<artifactId>bcprov-jdk16</artifactId>
+			<artifactId>bcprov-jdk15on</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>commons-io</groupId>

--- a/ssl-proxies/src/main/java/org/globus/gsi/bc/BouncyCastleCertProcessingFactory.java
+++ b/ssl-proxies/src/main/java/org/globus/gsi/bc/BouncyCastleCertProcessingFactory.java
@@ -14,6 +14,7 @@
  */
 package org.globus.gsi.bc;
 
+import org.bouncycastle.asn1.x500.style.BCStyle;
 import org.globus.gsi.util.CertificateLoadUtil;
 import org.globus.gsi.util.ProxyCertificateUtil;
 
@@ -48,13 +49,13 @@ import org.bouncycastle.x509.X509V3CertificateGenerator;
 import org.bouncycastle.jce.PKCS10CertificationRequest;
 import org.bouncycastle.jce.provider.X509CertificateObject;
 import org.bouncycastle.asn1.DERSet;
-import org.bouncycastle.asn1.DERObject;
 import org.bouncycastle.asn1.DERBitString;
 import org.bouncycastle.asn1.x509.X509Name;
+import org.bouncycastle.asn1.ASN1Primitive;
 import org.bouncycastle.asn1.ASN1InputStream;
 import org.bouncycastle.asn1.ASN1Sequence;
+import org.bouncycastle.asn1.x509.Certificate;
 import org.bouncycastle.asn1.x509.TBSCertificateStructure;
-import org.bouncycastle.asn1.x509.X509CertificateStructure;
 import org.bouncycastle.asn1.x509.X509Extensions;
 import org.bouncycastle.asn1.x509.X509Extension;
 import org.bouncycastle.asn1.x509.KeyUsage;
@@ -149,7 +150,7 @@ public class BouncyCastleCertProcessingFactory {
         throws IOException, GeneralSecurityException {
 
         ASN1InputStream derin = new ASN1InputStream(certRequestInputStream);
-        DERObject reqInfo = derin.readObject();
+        ASN1Primitive reqInfo = derin.readObject();
         PKCS10CertificationRequest certReq = new PKCS10CertificationRequest((ASN1Sequence) reqInfo);
 
         boolean rs = certReq.verify();
@@ -413,11 +414,11 @@ public class BouncyCastleCertProcessingFactory {
                     X509Extension ext;
 
                     // handle key usage ext
-                    ext = extensions.getExtension(X509Extensions.KeyUsage);
+                    ext = extensions.getExtension(X509Extension.keyUsage);
                     if (ext != null) {
 
                         // TBD: handle this better
-                        if (extSet != null && (extSet.get(X509Extensions.KeyUsage.getId()) != null)) {
+                        if (extSet != null && (extSet.get(X509Extension.keyUsage.getId()) != null)) {
                             String err = i18n.getMessage("keyUsageExt");
                             throw new GeneralSecurityException(err);
                         }
@@ -437,7 +438,7 @@ public class BouncyCastleCertProcessingFactory {
 
                         bits = new DERBitString(bytes, bits.getPadBits());
 
-                        certGen.addExtension(X509Extensions.KeyUsage, ext.isCritical(), bits);
+                        certGen.addExtension(X509Extension.keyUsage, ext.isCritical(), bits);
                     }
                 }
 
@@ -481,7 +482,7 @@ public class BouncyCastleCertProcessingFactory {
         X509NameHelper issuer = new X509NameHelper(issuerDN);
 
         X509NameHelper subject = new X509NameHelper(issuerDN);
-        subject.add(X509Name.CN, (cnValue == null) ? delegDN : cnValue);
+        subject.add(BCStyle.CN, (cnValue == null) ? delegDN : cnValue);
 
         certGen.setSubjectDN(subject.getAsName());
         certGen.setIssuerDN(issuer.getAsName());
@@ -572,7 +573,7 @@ public class BouncyCastleCertProcessingFactory {
         String cnValue) throws IOException, GeneralSecurityException {
 
         ASN1InputStream derin = new ASN1InputStream(certRequestInputStream);
-        DERObject reqInfo = derin.readObject();
+        ASN1Primitive reqInfo = derin.readObject();
         PKCS10CertificationRequest certReq = new PKCS10CertificationRequest((ASN1Sequence) reqInfo);
 
         boolean rs = certReq.verify();
@@ -817,11 +818,11 @@ public class BouncyCastleCertProcessingFactory {
                     X509Extension ext;
 
                     // handle key usage ext
-                    ext = extensions.getExtension(X509Extensions.KeyUsage);
+                    ext = extensions.getExtension(X509Extension.keyUsage);
                     if (ext != null) {
 
                         // TBD: handle this better
-                        if (extSet != null && (extSet.get(X509Extensions.KeyUsage.getId()) != null)) {
+                        if (extSet != null && (extSet.get(X509Extension.keyUsage.getId()) != null)) {
                             String err = i18n.getMessage("keyUsageExt");
                             throw new GeneralSecurityException(err);
                         }
@@ -841,7 +842,7 @@ public class BouncyCastleCertProcessingFactory {
 
                         bits = new DERBitString(bytes, bits.getPadBits());
 
-                        certGen.addExtension(X509Extensions.KeyUsage, ext.isCritical(), bits);
+                        certGen.addExtension(X509Extension.keyUsage, ext.isCritical(), bits);
                     }
                 }
 
@@ -883,7 +884,7 @@ public class BouncyCastleCertProcessingFactory {
         }
         X509NameHelper issuer = new X509NameHelper(issuerDN);
         X509NameHelper subject = new X509NameHelper(issuerDN);
-        subject.add(X509Name.CN, (cnValue == null) ? delegDN : cnValue);
+        subject.add(BCStyle.CN, (cnValue == null) ? delegDN : cnValue);
 
         certGen.setSubjectDN(subject.getAsName());
         certGen.setIssuerDN(issuer.getAsName());
@@ -922,9 +923,9 @@ public class BouncyCastleCertProcessingFactory {
      */
     public X509Certificate loadCertificate(InputStream in) throws IOException, GeneralSecurityException {
         ASN1InputStream derin = new ASN1InputStream(in);
-        DERObject certInfo = derin.readObject();
+        ASN1Primitive certInfo = derin.readObject();
         ASN1Sequence seq = ASN1Sequence.getInstance(certInfo);
-        return new X509CertificateObject(new X509CertificateStructure(seq));
+        return new X509CertificateObject(Certificate.getInstance(seq));
     }
 
     /**

--- a/ssl-proxies/src/main/java/org/globus/gsi/bc/BouncyCastleOpenSSLKey.java
+++ b/ssl-proxies/src/main/java/org/globus/gsi/bc/BouncyCastleOpenSSLKey.java
@@ -28,8 +28,8 @@ import java.security.Security;
 import java.security.interfaces.RSAPrivateCrtKey;
 import java.security.spec.PKCS8EncodedKeySpec;
 import org.bouncycastle.asn1.ASN1InputStream;
+import org.bouncycastle.asn1.ASN1Primitive;
 import org.bouncycastle.asn1.ASN1Sequence;
-import org.bouncycastle.asn1.DERObject;
 import org.bouncycastle.asn1.DERObjectIdentifier;
 import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
 import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
@@ -121,12 +121,12 @@ public class BouncyCastleOpenSSLKey extends OpenSSLKey {
 				}
 				ByteArrayInputStream bis = new ByteArrayInputStream(data);
 				ASN1InputStream derin = new ASN1InputStream(bis);
-				DERObject keyInfo = derin.readObject();
+				ASN1Primitive keyInfo = derin.readObject();
 
 				DERObjectIdentifier rsaOid = PKCSObjectIdentifiers.rsaEncryption;
 				AlgorithmIdentifier rsa = new AlgorithmIdentifier(rsaOid);
 				PrivateKeyInfo pkeyinfo = new PrivateKeyInfo(rsa, keyInfo);
-				DERObject derkey = pkeyinfo.getDERObject();
+				ASN1Primitive derkey = pkeyinfo.toASN1Primitive();
 				byte[] keyData = BouncyCastleUtil.toByteArray(derkey);
 				// The DER object needs to be mangled to
 				// create a proper ProvateKeyInfo object
@@ -150,10 +150,10 @@ public class BouncyCastleOpenSSLKey extends OpenSSLKey {
 				&& (format.equalsIgnoreCase("PKCS#8") || format
 						.equalsIgnoreCase("PKCS8"))) {
 			try {
-				DERObject keyInfo = BouncyCastleUtil.toDERObject(key
+				ASN1Primitive keyInfo = BouncyCastleUtil.toASN1Primitive(key
 						.getEncoded());
 				PrivateKeyInfo pkey = new PrivateKeyInfo((ASN1Sequence) keyInfo);
-				DERObject derKey = pkey.getPrivateKey();
+				ASN1Primitive derKey = pkey.getPrivateKey();
 				return BouncyCastleUtil.toByteArray(derKey);
 			} catch (IOException e) {
 				// that should never happen
@@ -169,7 +169,7 @@ public class BouncyCastleOpenSSLKey extends OpenSSLKey {
 					.getPrivateExponent(), pKey.getPrimeP(), pKey.getPrimeQ(),
 					pKey.getPrimeExponentP(), pKey.getPrimeExponentQ(), pKey
 							.getCrtCoefficient());
-			DERObject ob = st.getDERObject();
+			ASN1Primitive ob = st.toASN1Primitive();
 
 			try {
 				return BouncyCastleUtil.toByteArray(ob);

--- a/ssl-proxies/src/main/java/org/globus/gsi/bc/BouncyCastleX509Extension.java
+++ b/ssl-proxies/src/main/java/org/globus/gsi/bc/BouncyCastleX509Extension.java
@@ -16,7 +16,7 @@ package org.globus.gsi.bc;
 
 import java.io.IOException;
 
-import org.bouncycastle.asn1.DEREncodable;
+import org.bouncycastle.asn1.ASN1Encodable;
 
 import org.globus.gsi.X509Extension;
 
@@ -36,22 +36,22 @@ public class BouncyCastleX509Extension extends X509Extension {
 	this(oid, false, null);
     }
     
-    public BouncyCastleX509Extension(String oid, DEREncodable value) {
+    public BouncyCastleX509Extension(String oid, ASN1Encodable value) {
 	this(oid, false, value);
     }
     
     public BouncyCastleX509Extension(String oid, boolean critical, 
-				     DEREncodable value) {
+				     ASN1Encodable value) {
 	super(oid, critical, null);
 	setValue(value);
     }
     
-    protected void setValue(DEREncodable value) {
+    protected void setValue(ASN1Encodable value) {
 	if (value == null) {
 	    return;
 	}
     	try {
-	    setValue(BouncyCastleUtil.toByteArray(value.getDERObject()));
+	    setValue(BouncyCastleUtil.toByteArray(value.toASN1Primitive()));
 	} catch (IOException e) {
 	    throw new RuntimeException(i18n.getMessage("byteArrayErr") +
 				       e.getMessage());

--- a/ssl-proxies/src/main/java/org/globus/gsi/proxy/ext/ProxyCertInfo.java
+++ b/ssl-proxies/src/main/java/org/globus/gsi/proxy/ext/ProxyCertInfo.java
@@ -20,11 +20,11 @@ import org.bouncycastle.asn1.DERObjectIdentifier;
 
 import java.io.IOException;
 
+import org.bouncycastle.asn1.ASN1Encodable;
 import org.bouncycastle.asn1.ASN1EncodableVector;
+import org.bouncycastle.asn1.ASN1Primitive;
 import org.bouncycastle.asn1.ASN1Sequence;
-import org.bouncycastle.asn1.DEREncodable;
 import org.bouncycastle.asn1.DERInteger;
-import org.bouncycastle.asn1.DERObject;
 import org.bouncycastle.asn1.DERSequence;
 
 /**
@@ -34,7 +34,7 @@ import org.bouncycastle.asn1.DERSequence;
  * ProxyCertInfo ::= SEQUENCE { pCPathLenConstraint      INTEGER (0..MAX) OPTIONAL, proxyPolicy ProxyPolicy }
  * </PRE>
  */
-public class ProxyCertInfo implements DEREncodable {
+public class ProxyCertInfo implements ASN1Encodable {
 
     /** ProxyCertInfo extension OID */
     public static final DERObjectIdentifier OID 
@@ -111,9 +111,9 @@ public class ProxyCertInfo implements DEREncodable {
         } else if (obj instanceof ASN1Sequence) {
             return new ProxyCertInfo((ASN1Sequence) obj);
         } else if (obj instanceof byte[]) {
-            DERObject derObj;
+            ASN1Primitive derObj;
             try {
-                derObj = CertificateUtil.toDERObject((byte[]) obj);
+                derObj = CertificateUtil.toASN1Primitive((byte[]) obj);
             } catch (IOException e) {
                 throw new IllegalArgumentException(e.getMessage(), e);
             }
@@ -129,14 +129,14 @@ public class ProxyCertInfo implements DEREncodable {
      *
      * @return <code>DERObject</code> the encoded representation of the extension.
      */
-    public DERObject getDERObject() {
+    public ASN1Primitive toASN1Primitive() {
         ASN1EncodableVector vec = new ASN1EncodableVector();
 
         if (this.pathLenConstraint != null) {
             vec.add(this.pathLenConstraint);
         }
 
-        vec.add(this.proxyPolicy.getDERObject());
+        vec.add(this.proxyPolicy.toASN1Primitive());
 
         return new DERSequence(vec);
     }

--- a/ssl-proxies/src/main/java/org/globus/gsi/proxy/ext/ProxyPolicy.java
+++ b/ssl-proxies/src/main/java/org/globus/gsi/proxy/ext/ProxyPolicy.java
@@ -14,10 +14,10 @@
  */
 package org.globus.gsi.proxy.ext;
 
+import org.bouncycastle.asn1.ASN1Encodable;
 import org.bouncycastle.asn1.ASN1EncodableVector;
+import org.bouncycastle.asn1.ASN1Primitive;
 import org.bouncycastle.asn1.ASN1Sequence;
-import org.bouncycastle.asn1.DEREncodable;
-import org.bouncycastle.asn1.DERObject;
 import org.bouncycastle.asn1.DERObjectIdentifier;
 import org.bouncycastle.asn1.DEROctetString;
 import org.bouncycastle.asn1.DERSequence;
@@ -27,7 +27,7 @@ import org.bouncycastle.asn1.DERTaggedObject;
  * Represents the policy part of the ProxyCertInfo extension. <BR> <PRE>
  * ProxyPolicy ::= SEQUENCE { policyLanguage    OBJECT IDENTIFIER, policy OCTET STRING OPTIONAL } </PRE>
  */
-public class ProxyPolicy implements DEREncodable {
+public class ProxyPolicy implements ASN1Encodable {
 
     /**
      * Impersonation proxy OID
@@ -58,7 +58,7 @@ public class ProxyPolicy implements DEREncodable {
         }
         this.policyLanguage = (DERObjectIdentifier) seq.getObjectAt(0);
         if (seq.size() > 1) {
-            DEREncodable obj = seq.getObjectAt(1);
+            ASN1Encodable obj = seq.getObjectAt(1);
             if (obj instanceof DERTaggedObject) {
                 obj = ((DERTaggedObject) obj).getObject();
             }
@@ -133,7 +133,7 @@ public class ProxyPolicy implements DEREncodable {
      * @return <code>DERObject</code> the encoded representation of the proxy
      *         policy.
      */
-    public DERObject getDERObject() {
+    public ASN1Primitive toASN1Primitive() {
 
         ASN1EncodableVector vec = new ASN1EncodableVector();
 

--- a/ssl-proxies/src/main/java/org/globus/gsi/trustmanager/X509ProxyCertPathValidator.java
+++ b/ssl-proxies/src/main/java/org/globus/gsi/trustmanager/X509ProxyCertPathValidator.java
@@ -500,12 +500,12 @@ public class X509ProxyCertPathValidator extends CertPathValidatorSpi {
             while (e.hasMoreElements()) {
                 oid = (DERObjectIdentifier) e.nextElement();
                 proxyExtension = extensions.getExtension(oid);
-                if (oid.equals(X509Extensions.SubjectAlternativeName)
-                        || oid.equals(X509Extensions.IssuerAlternativeName)) {
+                if (oid.equals(X509Extension.subjectAlternativeName)
+                        || oid.equals(X509Extension.issuerAlternativeName)) {
                     // No Alt name extensions - 3.2 & 3.5
                     throw new CertPathValidatorException(
                             "Proxy violation: no Subject or Issuer Alternative Name");
-                } else if (oid.equals(X509Extensions.BasicConstraints)) {
+                } else if (oid.equals(X509Extension.basicConstraints)) {
                     // Basic Constraint must not be true - 3.8
                     BasicConstraints basicExt =
                             CertificateUtil.getBasicConstraints(proxyExtension);
@@ -513,7 +513,7 @@ public class X509ProxyCertPathValidator extends CertPathValidatorSpi {
                         throw new CertPathValidatorException(
                                 "Proxy violation: Basic Constraint CA is set to true");
                     }
-                } else if (oid.equals(X509Extensions.KeyUsage)) {
+                } else if (oid.equals(X509Extension.keyUsage)) {
                     proxyKeyUsage = proxyExtension;
 
                     checkKeyUsage(issuer, proxyExtension);
@@ -543,7 +543,7 @@ public class X509ProxyCertPathValidator extends CertPathValidatorSpi {
     }
 
     private void checkExtension(DERObjectIdentifier oid, X509Extension proxyExtension, X509Extension proxyKeyUsage) throws CertPathValidatorException {
-        if (oid.equals(X509Extensions.KeyUsage)) {
+        if (oid.equals(X509Extension.keyUsage)) {
             // If issuer has it then proxy must have it also
             if (proxyKeyUsage == null) {
                 throw new CertPathValidatorException(

--- a/ssl-proxies/src/main/java/org/globus/gsi/util/CertificateIOUtil.java
+++ b/ssl-proxies/src/main/java/org/globus/gsi/util/CertificateIOUtil.java
@@ -107,7 +107,7 @@ public final class CertificateIOUtil {
     public static byte[] encodePrincipal(X509Name subject) throws IOException {
         ByteArrayOutputStream bout = new ByteArrayOutputStream();
         DEROutputStream der = new DEROutputStream(bout);
-        der.writeObject(subject.getDERObject());
+        der.writeObject(subject.toASN1Primitive());
         return bout.toByteArray();
     }
 

--- a/ssl-proxies/src/test/java/org/globus/gsi/bc/BouncyCastleCertProcessingFactoryTest.java
+++ b/ssl-proxies/src/test/java/org/globus/gsi/bc/BouncyCastleCertProcessingFactoryTest.java
@@ -26,6 +26,11 @@ import org.globus.gsi.proxy.ext.ProxyPolicy;
 import org.globus.gsi.proxy.ext.ProxyCertInfo;
 import org.globus.gsi.proxy.ext.ProxyCertInfoExtension;
 
+import org.bouncycastle.asn1.ASN1Boolean;
+import org.bouncycastle.asn1.ASN1Encodable;
+import org.bouncycastle.asn1.ASN1Integer;
+import org.bouncycastle.asn1.DERBoolean;
+import org.bouncycastle.asn1.DERSequence;
 import org.bouncycastle.asn1.x509.BasicConstraints;
 import org.bouncycastle.asn1.x509.X509Extensions;
 
@@ -88,9 +93,10 @@ public class BouncyCastleCertProcessingFactoryTest extends TestCase {
     X509ExtensionSet extSet = new X509ExtensionSet();
     ext = new X509Extension(oid, critical, expectedValue.getBytes());
     extSet.add(ext);
-    
-    BasicConstraints constraints = new BasicConstraints(false, 15);
-    ext = new BouncyCastleX509Extension(X509Extensions.BasicConstraints.getId(),
+
+    DERSequence seq = new DERSequence(new ASN1Encodable[] { DERBoolean.FALSE, new ASN1Integer(15) });
+    BasicConstraints constraints = BasicConstraints.getInstance(seq);
+    ext = new BouncyCastleX509Extension(org.bouncycastle.asn1.x509.X509Extension.basicConstraints.getId(),
                         false, constraints);
     extSet.add(ext);
     

--- a/ssl-proxies/src/test/java/org/globus/gsi/proxy/ext/ProxyCertInfoTest.java
+++ b/ssl-proxies/src/test/java/org/globus/gsi/proxy/ext/ProxyCertInfoTest.java
@@ -24,7 +24,7 @@ import org.globus.gsi.proxy.ext.ProxyCertInfo;
 
 import org.bouncycastle.asn1.DERObjectIdentifier;
 import org.bouncycastle.asn1.DEROutputStream;
-import org.bouncycastle.asn1.DERObject;
+import org.bouncycastle.asn1.ASN1Primitive;
 import org.bouncycastle.asn1.ASN1Sequence;
 
 import junit.framework.TestCase;
@@ -63,7 +63,7 @@ public class ProxyCertInfoTest extends TestCase {
 	ByteArrayInputStream bIn = 
 	    new ByteArrayInputStream(bOut.toByteArray());
 	ASN1InputStream dIn = new ASN1InputStream(bIn);
-	DERObject obj = dIn.readObject();
+	ASN1Primitive obj = dIn.readObject();
 	
 	assertTrue(obj instanceof ASN1Sequence);
 	
@@ -112,7 +112,7 @@ public class ProxyCertInfoTest extends TestCase {
 	ByteArrayInputStream bIn = 
 	    new ByteArrayInputStream(bOut.toByteArray());
 	ASN1InputStream dIn = new ASN1InputStream(bIn);
-	DERObject obj = dIn.readObject();
+	ASN1Primitive obj = dIn.readObject();
 
 	ProxyCertInfo testInfo = new ProxyCertInfo((ASN1Sequence)obj);
 


### PR DESCRIPTION
Hi,

Could you please update the dependency on Bouncy Castle ? The new versions of Bouncy Castle do not preserve the binary compatibility and this is causing issues when components using different versions of Bouncy Castle are mixed together. This pull request updates the dependency to the latest release of Bouncy Castle. This is a minimal upgrade to compile and run the tests, there are some deprecations left.

Thank you.
