### PR TITLE
Rename the parent artifact "parent". The name "jglobus-all" is confusing...

### DIFF
--- a/axis/pom.xml
+++ b/axis/pom.xml
@@ -1,6 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>jglobus-all</artifactId>
+        <artifactId>parent</artifactId>
         <groupId>org.jglobus</groupId>
         <version>2.1-SNAPSHOT</version>
     </parent>

--- a/container-test-utils/pom.xml
+++ b/container-test-utils/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
-    <artifactId>jglobus-all</artifactId>
+    <artifactId>parent</artifactId>
     <groupId>org.jglobus</groupId>
     <version>2.1-SNAPSHOT</version>
   </parent>

--- a/gram/pom.xml
+++ b/gram/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<artifactId>jglobus-all</artifactId>
+		<artifactId>parent</artifactId>
 		<groupId>org.jglobus</groupId>
 		<version>2.1-SNAPSHOT</version>
 	</parent>

--- a/gridftp/pom.xml
+++ b/gridftp/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<parent>
-		<artifactId>jglobus-all</artifactId>
+		<artifactId>parent</artifactId>
 		<groupId>org.jglobus</groupId>
 		<version>2.1-SNAPSHOT</version>
 	</parent>

--- a/gss/pom.xml
+++ b/gss/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
-    <artifactId>jglobus-all</artifactId>
+    <artifactId>parent</artifactId>
     <groupId>org.jglobus</groupId>
     <version>2.1-SNAPSHOT</version>
   </parent>

--- a/io/pom.xml
+++ b/io/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<parent>
-		<artifactId>jglobus-all</artifactId>
+		<artifactId>parent</artifactId>
 		<groupId>org.jglobus</groupId>
 		<version>2.1-SNAPSHOT</version>
 	</parent>

--- a/jsse/pom.xml
+++ b/jsse/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
-    <artifactId>jglobus-all</artifactId>
+    <artifactId>parent</artifactId>
     <groupId>org.jglobus</groupId>
     <version>2.1-SNAPSHOT</version>
   </parent>

--- a/myproxy/pom.xml
+++ b/myproxy/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<parent>
-		<artifactId>jglobus-all</artifactId>
+		<artifactId>parent</artifactId>
 		<groupId>org.jglobus</groupId>
 		<version>2.1-SNAPSHOT</version>
 	</parent>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.jglobus</groupId>
-	<artifactId>jglobus-all</artifactId>
+	<artifactId>parent</artifactId>
 	<version>2.1-SNAPSHOT</version>
 	<modules>
 		<module>test-utils</module>

--- a/ssl-proxies-tomcat/pom.xml
+++ b/ssl-proxies-tomcat/pom.xml
@@ -1,6 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<parent>
-		<artifactId>jglobus-all</artifactId>
+		<artifactId>parent</artifactId>
 		<groupId>org.jglobus</groupId>
 		<version>2.1-SNAPSHOT</version>
 	</parent>

--- a/ssl-proxies/pom.xml
+++ b/ssl-proxies/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<parent>
-		<artifactId>jglobus-all</artifactId>
+		<artifactId>parent</artifactId>
 		<groupId>org.jglobus</groupId>
 		<version>2.1-SNAPSHOT</version>
 	</parent>

--- a/test-utils/pom.xml
+++ b/test-utils/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
-    <artifactId>jglobus-all</artifactId>
+    <artifactId>parent</artifactId>
     <groupId>org.jglobus</groupId>
     <version>2.1-SNAPSHOT</version>
   </parent>


### PR DESCRIPTION
The artifactId in the parent pom.xml is currently "jglobus-all" which is confusing. This is the parent on which all the other artifacts depend, it is not a meta artifact that depends on all the other artifacts which is what the current name suggest. This commit changes the name to "parent" instead which is less confusing.
