### PR TITLE
Make input streams buffered and close them after use

### DIFF
--- a/gridftp/src/main/java/org/globus/ftp/examples/LocalCredentialHelper.java
+++ b/gridftp/src/main/java/org/globus/ftp/examples/LocalCredentialHelper.java
@@ -1,9 +1,5 @@
 package org.globus.ftp.examples;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.globus.util.ConfigUtil;
@@ -11,6 +7,10 @@ import org.gridforum.jgss.ExtendedGSSCredential;
 import org.gridforum.jgss.ExtendedGSSManager;
 import org.ietf.jgss.GSSCredential;
 import org.ietf.jgss.GSSException;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
 
 public class LocalCredentialHelper {
 
@@ -23,11 +23,14 @@ public class LocalCredentialHelper {
     }
 
     public GSSCredential getCredential(File proxyFile) throws IOException, GSSException {
-        
+
         byte[] proxyBytes = new byte[(int) proxyFile.length()];
         FileInputStream in = new FileInputStream(proxyFile);
-        in.read(proxyBytes);
-        in.close();
+        try {
+            in.read(proxyBytes);
+        } finally {
+            in.close();
+        }
         ExtendedGSSManager manager = (ExtendedGSSManager) ExtendedGSSManager.getInstance();
         return manager.createCredential(proxyBytes, ExtendedGSSCredential.IMPEXP_OPAQUE,
                 GSSCredential.DEFAULT_LIFETIME, null, GSSCredential.INITIATE_AND_ACCEPT);

--- a/gridftp/src/test/java/org/globus/ftp/test/SimpleTarTransfer.java
+++ b/gridftp/src/test/java/org/globus/ftp/test/SimpleTarTransfer.java
@@ -1,8 +1,5 @@
 package org.globus.ftp.test;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
 import org.globus.ftp.GridFTPClient;
 import org.globus.ftp.Session;
 import org.globus.gsi.gssapi.auth.IdentityAuthorization;
@@ -11,6 +8,10 @@ import org.gridforum.jgss.ExtendedGSSCredential;
 import org.gridforum.jgss.ExtendedGSSManager;
 import org.ietf.jgss.GSSCredential;
 import org.ietf.jgss.GSSException;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
 
 public class SimpleTarTransfer {
 
@@ -69,8 +70,11 @@ public class SimpleTarTransfer {
         File proxyFile = new File(ConfigUtil.discoverProxyLocation());
         byte[] proxyBytes = new byte[(int) proxyFile.length()];
         FileInputStream in = new FileInputStream(proxyFile);
-        in.read(proxyBytes);
-        in.close();
+        try {
+            in.read(proxyBytes);
+        } finally {
+            in.close();
+        }
         ExtendedGSSManager manager = (ExtendedGSSManager) ExtendedGSSManager.getInstance();
         return manager.createCredential(proxyBytes, ExtendedGSSCredential.IMPEXP_OPAQUE,
             GSSCredential.DEFAULT_LIFETIME, null, GSSCredential.INITIATE_AND_ACCEPT);

--- a/jsse/src/main/java/org/globus/gsi/jsse/GlobusSSLHelper.java
+++ b/jsse/src/main/java/org/globus/gsi/jsse/GlobusSSLHelper.java
@@ -18,6 +18,8 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.globus.gsi.provider.GlobusProvider;
 import org.globus.gsi.stores.ResourceCertStoreParameters;
+
+import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -36,7 +38,7 @@ import java.security.cert.CertificateException;
 /**
  * This is a utility class designed to simplify common tasks required for
  * configuring the globus ssl support.
- * 
+ *
  * @version 1.0
  * @since 1.0
  */
@@ -51,7 +53,7 @@ public final class GlobusSSLHelper {
 	 * Create a trust store using the supplied details. Java SSL requires the
 	 * trust store to be supplied as a java.security.KeyStore, so this will
 	 * create a KeyStore containing all of the Trust Anchors.
-	 * 
+	 *
 	 * @param provider
 	 *            The Java security provider to use.
 	 * @param trustAnchorStoreType
@@ -78,9 +80,13 @@ public final class GlobusSSLHelper {
 						provider);
 			}
 			InputStream keyStoreInput = getStream(trustAnchorStoreLocation);
-			trustAnchorStore.load(keyStoreInput,
-					trustAnchorStorePassword == null ? null
-							: trustAnchorStorePassword.toCharArray());
+                        try {
+                            trustAnchorStore.load(new BufferedInputStream(keyStoreInput),
+                                    trustAnchorStorePassword == null ? null
+                                            : trustAnchorStorePassword.toCharArray());
+                        } finally {
+                            keyStoreInput.close();
+                        }
 			return trustAnchorStore;
 		} catch (KeyStoreException e) {
 			throw new GlobusSSLConfigurationException(e);
@@ -98,7 +104,7 @@ public final class GlobusSSLHelper {
 	/**
 	 * Create a configured CredentialStore using the supplied parameters. The
 	 * credential store is a java.security.KeyStore.
-	 * 
+	 *
 	 * @param provider
 	 *            The Java security provider to use.
 	 * @param credentialStoreType
@@ -125,9 +131,13 @@ public final class GlobusSSLHelper {
 						provider);
 			}
 			InputStream keyStoreInput = getStream(credentialStoreLocation);
-			credentialStore.load(keyStoreInput,
+                        try {
+                            credentialStore.load(new BufferedInputStream(keyStoreInput),
 					credentialStorePassword == null ? null
 							: credentialStorePassword.toCharArray());
+                        } finally {
+                            keyStoreInput.close();
+                        }
 			return credentialStore;
 		} catch (KeyStoreException e) {
 			throw new GlobusSSLConfigurationException(e);
@@ -172,7 +182,7 @@ public final class GlobusSSLHelper {
 	 * both CRL's and non-trusted certs. For the purposes of this method, we
 	 * assume that only crl's will be loaded. This can only be used with the
 	 * Globus provided Certificate Store.
-	 * 
+	 *
 	 * @param crlPattern
 	 *            The pattern which defines the locations of the CRL's
 	 * @return A configured Java CertStore containing the specified CRL's

--- a/ssl-proxies/src/main/java/org/globus/gsi/stores/ResourceCRL.java
+++ b/ssl-proxies/src/main/java/org/globus/gsi/stores/ResourceCRL.java
@@ -16,14 +16,13 @@
 package org.globus.gsi.stores;
 
 import org.globus.gsi.util.CertificateLoadUtil;
+import org.globus.util.GlobusResource;
 
+import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.GeneralSecurityException;
 import java.security.cert.X509CRL;
-
-
-import org.globus.util.GlobusResource;
 
 /**
  * Created by IntelliJ IDEA.
@@ -55,19 +54,20 @@ public class ResourceCRL extends AbstractResourceSecurityWrapper<X509CRL> {
 
     @Override
     protected X509CRL create(GlobusResource resource) throws ResourceStoreException {
-        InputStream is = null;
         try {
-            is = resource.getInputStream();
-            return CertificateLoadUtil.loadCrl(is);
+            InputStream is = resource.getInputStream();
+            try {
+                return CertificateLoadUtil.loadCrl(new BufferedInputStream(is));
+            } finally {
+                try {
+                    is.close();
+                } catch (IOException ignored) {
+                }
+            }
         } catch (IOException e) {
             throw new ResourceStoreException(e);
         } catch (GeneralSecurityException e) {
             throw new ResourceStoreException(e);
-        } finally {
-            try {
-                if (is != null) is.close();
-            } catch (IOException e) {
-            }
         }
     }
 

--- a/ssl-proxies/src/main/java/org/globus/gsi/stores/ResourceTrustAnchor.java
+++ b/ssl-proxies/src/main/java/org/globus/gsi/stores/ResourceTrustAnchor.java
@@ -17,14 +17,15 @@ package org.globus.gsi.stores;
 
 import org.globus.gsi.util.CertificateIOUtil;
 import org.globus.gsi.util.CertificateLoadUtil;
+import org.globus.util.GlobusResource;
 
+import java.io.BufferedInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.security.GeneralSecurityException;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.TrustAnchor;
 import java.security.cert.X509Certificate;
-
-import org.globus.util.GlobusResource;
 
 
 /**
@@ -65,7 +66,15 @@ public class ResourceTrustAnchor extends AbstractResourceSecurityWrapper<TrustAn
     protected TrustAnchor create(GlobusResource globusResource) throws ResourceStoreException {
         X509Certificate certificate;
         try {
-            certificate = CertificateLoadUtil.loadCertificate(globusResource.getInputStream());
+            InputStream inputStream = globusResource.getInputStream();
+            try {
+                certificate = CertificateLoadUtil.loadCertificate(new BufferedInputStream(inputStream));
+            } finally {
+                try {
+                    inputStream.close();
+                } catch (IOException ignored) {
+                }
+            }
         } catch (IOException e) {
             throw new ResourceStoreException(e);
         } catch (GeneralSecurityException e) {

--- a/ssl-proxies/src/main/java/org/globus/util/GlobusPathMatchingResourcePatternResolver.java
+++ b/ssl-proxies/src/main/java/org/globus/util/GlobusPathMatchingResourcePatternResolver.java
@@ -1,13 +1,11 @@
 package org.globus.util;
 
-import org.apache.commons.codec.net.URLCodec;
-
 import java.io.File;
-import java.util.Vector;
-import java.util.regex.Pattern;
-import java.util.regex.Matcher;
-import java.net.URL;
 import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Vector;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Provides methods to resolve locationPatterns and return GlobusResource
@@ -138,15 +136,25 @@ public class GlobusPathMatchingResourcePatternResolver {
     }
 
     /**
-     * Go through every directory recursively and perform parseFilesInDirectory method.
+     * Recursive variant of parseFilesInDirectory.
      * @param currentDirectory The currentDirectory to explore.
      */
     private void parseDirectoryStructure(File currentDirectory) {
-        parseFilesInDirectory(currentDirectory);
-        File[] directoryContents = currentDirectory.listFiles();
-        if (directoryContents != null) {
+        File[] directoryContents;
+        if (currentDirectory.isDirectory()) {
+            directoryContents = currentDirectory.listFiles();    //Get a list of the files and directories
+        } else {
+            directoryContents = new File[] { currentDirectory };
+        }
+        if(directoryContents != null){
             for (File currentFile : directoryContents) {
-                if (currentFile.isDirectory()) {
+                if (currentFile.isFile()) { //We are only interested in files not directories
+                    String absolutePath = currentFile.getAbsolutePath();
+                    Matcher locationPatternMatcher = locationPattern.matcher(absolutePath);
+                    if (locationPatternMatcher.find()) {
+                        pathsMatchingLocationPattern.add(new GlobusResource(absolutePath));
+                    }
+                } else if (currentFile.isDirectory()) {
                     parseDirectoryStructure(currentFile);
                 }
             }


### PR DESCRIPTION
Several input streams were unbuffered and others were not closed
after use.

This fix has taken one to two seconds off a simple srmPing invocation.
