### PR TITLE
Signal end-of-stream when remote sends a CLOSE notification

### DIFF
--- a/gss/src/main/java/org/globus/gsi/gssapi/ClosedGSSException.java
+++ b/gss/src/main/java/org/globus/gsi/gssapi/ClosedGSSException.java
@@ -1,0 +1,9 @@
+package org.globus.gsi.gssapi;
+
+import org.ietf.jgss.GSSException;
+
+public class ClosedGSSException extends GSSException {
+    public ClosedGSSException() {
+        super(CONTEXT_EXPIRED);
+    }
+}

--- a/gss/src/main/java/org/globus/gsi/gssapi/GlobusGSSContextImpl.java
+++ b/gss/src/main/java/org/globus/gsi/gssapi/GlobusGSSContextImpl.java
@@ -830,6 +830,11 @@ public class GlobusGSSContextImpl implements ExtendedGSSContext {
 			// More data needed from peer
 			break;
 		}
+                else if (result.getStatus() ==
+                        SSLEngineResult.Status.CLOSED) {
+                    throw new ClosedGSSException();
+                }
+
 		if (result.getStatus() !=
 			SSLEngineResult.Status.OK) {
                 	throw new GlobusGSSException(GSSException.FAILURE,
@@ -845,6 +850,8 @@ public class GlobusGSSContextImpl implements ExtendedGSSContext {
                 throw new GlobusGSSException(GSSException.BAD_MIC, e);
             else
                 throw new GlobusGSSException(GSSException.FAILURE, e);
+        } catch (GSSException e) {
+            throw e;
 	} catch (Exception e) {
             throw new GlobusGSSException(GSSException.FAILURE, e);
 	}


### PR DESCRIPTION
GlobusGSSCredentialImpl fails when the remote initiates a proper
SSL shutdown. The patch changes the logic such that rather
than throwing a generic error, the new ClosedGSSException is
thrown. The InputStream implementation recognizes this exception
and signals end-of-stream to the caller.
