### PR TITLE
Enable TLS 1.2 clients

### DIFF
--- a/gss/src/main/java/org/globus/gsi/gssapi/SSLUtil.java
+++ b/gss/src/main/java/org/globus/gsi/gssapi/SSLUtil.java
@@ -108,14 +108,14 @@ public class SSLUtil {
     
     /**
      * Determines if a given header is a SSLv3 packet
-     * (has a SSL header)
+     * (has a SSL header) or a backward compatible version of TLS
+     * using the same header format.
      *
      * @return true if the header is a SSLv3 header. False, otherwise.
      */
     public static final boolean isSSLv3Packet(byte[] header) {
-        return ( (header[0] >= 20 && header[0] <= 26 &&
-                  (header[1] == 3 && (header[2] == 0 || header[2] == 1) ||
-                   header[1] == 2 && header[2] == 0)) );
+        return header[0] >= 20 && header[0] <= 26 &&
+            (header[1] == 3 || (header[1] == 2 && header[2] == 0));
     }
     
     /**


### PR DESCRIPTION
SSLUtil fails to recognize TLS 1.2 packets. Regardless of whether
the server supports TLS 1.2, failure to recognize the header prevents
it from falling back to an earlier revision of the protocol.

The change enables forward compatibility. Based on my reading of the
TLS 1.2 RFC, I think the server should recognize versions higher than
it actually supports and reply with a lower version number. I assume
that as long as the TLS major version is unchanged, the header format
is compatible.
