### PR TITLE
Only cache CA's signing policy as not found after searching all entries

### DIFF
--- a/ssl-proxies/src/main/java/org/globus/gsi/stores/ResourceSigningPolicyStore.java
+++ b/ssl-proxies/src/main/java/org/globus/gsi/stores/ResourceSigningPolicyStore.java
@@ -129,7 +129,6 @@ public class ResourceSigningPolicyStore implements SigningPolicyStore {
                     logger.warn("Failed to load signing policy: " + filename);
                     logger.debug("Failed to load signing policy: " + filename, e);
                     invalidPoliciesCache.put(filename, now);
-                    invalidPoliciesCache.put(caPrincipalName, now);
                 }
                 continue;
             }
@@ -156,7 +155,6 @@ public class ResourceSigningPolicyStore implements SigningPolicyStore {
                     logger.warn("Failed to load signing policy: " + filename);
                     logger.debug("Failed to load signing policy: " + filename, e);
                     invalidPoliciesCache.put(filename, now);
-                    invalidPoliciesCache.put(caPrincipalName, now);
                 }
                 continue;
             }


### PR DESCRIPTION
Currently, when ResourceSigningPolicyStore searches all signing policy
files, a failure to load any file results in the CA being stored in the
not-found cache, even though the CA likely has nothing to do with the
signing-policy file that failed to load.

A separate bug (in how wildcards are handled) means the scan through all
files will certainly fail if any CA has been removed since the JGlobus
application started.

Therefore, if a CA's hash is calculated incorrectly and some CA has been
removed then the CA's entry will be found the first time, but marked
in the negative cache.  Subsequent attempts to find the CA's signing
policy will fail.

This patch fixes this by only marking the CA as not found after an
exhaustive search.

Target: master
Request: 2.1
Request: 2.0
