### PR TITLE
Avoid memory leak and stale information when scanning directories

### DIFF
--- a/ssl-proxies/src/main/java/org/globus/gsi/stores/ResourceSigningPolicyStore.java
+++ b/ssl-proxies/src/main/java/org/globus/gsi/stores/ResourceSigningPolicyStore.java
@@ -45,7 +45,6 @@ import org.globus.util.GlobusPathMatchingResourcePatternResolver;
  */
 public class ResourceSigningPolicyStore implements SigningPolicyStore {
 
-    private GlobusPathMatchingResourcePatternResolver globusResolver = new GlobusPathMatchingResourcePatternResolver();
     private Map<URI, ResourceSigningPolicy> signingPolicyFileMap = new HashMap<URI, ResourceSigningPolicy>();
     private Map<String, SigningPolicy> policyMap = new HashMap<String, SigningPolicy>();
     private ResourceSigningPolicyStoreParameters parameters;
@@ -94,8 +93,8 @@ public class ResourceSigningPolicyStore implements SigningPolicyStore {
     private synchronized void loadPolicy(String hash, String caPrincipalName) throws SigningPolicyStoreException {
 
         String locations = this.parameters.getTrustRootLocations();
-        GlobusResource[] resources;
-        resources = globusResolver.getResources(locations);
+        GlobusResource[] resources = new GlobusPathMatchingResourcePatternResolver().
+                getResources(locations);
 
         long now = System.currentTimeMillis();
         boolean found_policy = false;


### PR DESCRIPTION
The GlobusPathMatchingResourcePatternResolver class can scan a
filesystem for files matching some pattern.  Instances of this class
maintain an internal list of matches.  Successive calls to the
getResources method will append matching file paths and return the
complete list.  Note that (currently) there is no mechanism to reset the
internal list.

The ResourceSigningPolicyStore reuses the same Resolver instance for all
loadPolicy method calls, with three bad effects:
1. files are included multiple times, potentially resulting in
    loading a policy file multiple times;
2. the result list will always increase, eventually triggering an
    OOM;
3. if a file is removed then, as the Resolver's result list will
    continue to have the file, an error will be reported.  The negative
    cache alieviates this third problem so an error is reported once
    every 10 hours.

This patch modifies the code so loadPolicy method creates a new Resolver
for each loadPolicy method call.  There is no additional filesystem
overhead (the previous code would also always scan the directory), but
the results are now accurate and do not contain duplicates.

Target: master
Request: 2.1
Request: 2.0
