### PR TITLE
fix: close the inner stream even if an exception occured.

### DIFF
--- a/gss/src/main/java/org/globus/gsi/gssapi/net/GssOutputStream.java
+++ b/gss/src/main/java/org/globus/gsi/gssapi/net/GssOutputStream.java
@@ -118,8 +118,11 @@ public abstract class GssOutputStream extends OutputStream {
     public void close()
 	throws IOException {
 	logger.debug("close");
-	flushData();
-	this.out.close();
+	try {
+		flushData();
+	} finally {
+		this.out.close();
+	}
     }
 
 }


### PR DESCRIPTION
same kind of error here:
```
FINE: Socket closed
java.net.SocketException: Socket closed
        at java.net.SocketOutputStream.socketWrite(SocketOutputStream.java:116)
        at java.net.SocketOutputStream.write(SocketOutputStream.java:153)
        at java.io.BufferedOutputStream.flushBuffer(BufferedOutputStream.java:82)
        at java.io.BufferedOutputStream.flush(BufferedOutputStream.java:140)
        at org.globus.ftp.extended.GridFTPOutputStream.writeToken(GridFTPOutputStream.java:60)
        at org.globus.ftp.extended.GridFTPOutputStream.flush(GridFTPOutputStream.java:43)
        at org.globus.gsi.gssapi.net.GssOutputStream.flushData(GssOutputStream.java:114)
        at org.globus.gsi.gssapi.net.GssOutputStream.close(GssOutputStream.java:121)
        at org.globus.ftp.vanilla.FTPControlChannel.close(FTPControlChannel.java:247)
        at org.globus.ftp.FTPClient.close(FTPClient.java:958)
        at org.globus.ftp.FTPClient.close(FTPClient.java:930)
        at org.globus.io.streams.GridFTPOutputStream.<init>(GridFTPOutputStream.java:115)
        at org.globus.io.streams.GridFTPOutputStream.<init>(GridFTPOutputStream.java:79)
        at org.globus.io.streams.GridFTPOutputStream.<init>(GridFTPOutputStream.java:37)
```
