### PR TITLE
Fix unused socket in DatagramSocketFactory

### DIFF
--- a/gss/src/main/java/org/globus/net/DatagramSocketFactory.java
+++ b/gss/src/main/java/org/globus/net/DatagramSocketFactory.java
@@ -69,7 +69,7 @@ public class DatagramSocketFactory {
         } else {
             DatagramSocket socket = new DatagramSocket(port, localAddr);
             socket.setSoTimeout(CoGProperties.getDefault().getSocketTimeout());
-            return new DatagramSocket(port, localAddr);
+            return socket;
         }
     }
 


### PR DESCRIPTION
DatagramSocket had been created twice in createDatagramSocket(int port, InetAddress localAddr).