### PR TITLE
Do not accumulate matches in GlobusPathMatchingResourcePatternResolver

### DIFF
--- a/ssl-proxies/src/main/java/org/globus/util/GlobusPathMatchingResourcePatternResolver.java
+++ b/ssl-proxies/src/main/java/org/globus/util/GlobusPathMatchingResourcePatternResolver.java
@@ -32,7 +32,7 @@ public class GlobusPathMatchingResourcePatternResolver {
       */
     private String mainClassPath = "";
     //Holds GlobusResource instances of all the paths which matched the locationPattern
-    private Vector<GlobusResource> pathsMatchingLocationPattern = new Vector<GlobusResource>();
+    private Vector<GlobusResource> pathsMatchingLocationPattern;
 
     public GlobusPathMatchingResourcePatternResolver() {
     }
@@ -64,6 +64,7 @@ public class GlobusPathMatchingResourcePatternResolver {
      * @return An array of GlobusResource containing all resources whose locaiton match the locationPattern
      */
     public GlobusResource[] getResources(String locationPattern) {
+        pathsMatchingLocationPattern = new Vector<GlobusResource>();
         String mainPath = "";
         if (locationPattern.startsWith("classpath:")) {
             String pathUntilWildcard = getPathUntilWildcard(locationPattern.replaceFirst("classpath:/", ""), false);


### PR DESCRIPTION
The results vector is not cleared between calls to getResources() in GlobusPathMatchingResourcePatternResolver. Classes which repeatedly call the same resolver instance will get cumulative results.

The issue appears in ResourceSecurityWrapperStore.loadResources().

The accumulation of resource results appears to cause a reference leak in the ReloadableTrustStore, holding old certificate data in memory after each reload. PEMKeyStore.caDelegate grows in size with each ReloadableTrustStore.reload().

This patch allocates a new pathsMatchingLocationPattern Vector for each getResources() call.