### PR TITLE
Relax proxy validation to be RFC-3820 compliant

### DIFF
--- a/ssl-proxies/src/main/java/org/globus/gsi/trustmanager/X509ProxyCertPathValidator.java
+++ b/ssl-proxies/src/main/java/org/globus/gsi/trustmanager/X509ProxyCertPathValidator.java
@@ -515,8 +515,6 @@ public class X509ProxyCertPathValidator extends CertPathValidatorSpi {
                     }
                 } else if (oid.equals(X509Extension.keyUsage)) {
                     proxyKeyUsage = proxyExtension;
-
-                    checkKeyUsage(issuer, proxyExtension);
                 }
             }
         }
@@ -532,14 +530,6 @@ public class X509ProxyCertPathValidator extends CertPathValidatorSpi {
             }
         }
 
-    }
-
-    private void checkKeyUsage(TBSCertificateStructure issuer, X509Extension proxyExtension) throws IOException, CertPathValidatorException {
-        EnumSet<KeyUsage> keyUsage = CertificateUtil.getKeyUsage(proxyExtension);
-        // these must not be asserted
-        if (keyUsage.contains(KeyUsage.NON_REPUDIATION) || keyUsage.contains(KeyUsage.KEY_CERTSIGN)) {
-            throw new CertPathValidatorException("Proxy violation: Key usage is asserted.");
-        }
     }
 
     private void checkExtension(ASN1ObjectIdentifier oid, X509Extension proxyExtension, X509Extension proxyKeyUsage) throws CertPathValidatorException {


### PR DESCRIPTION
Motivation:

Nothing in RFC-3820 states that an X.509 proxy certificate cannot assert
KeyUsage; however, such certificates are currently rejected by JGlobus.
This discrepency is likely due to code developed against a draft version
of the RFC and not subsequently updated, but it is certainly preventing
the adoption of RFC proxies as some CAs assert NON_REPUDIATION as a
KeyUsage.

Modification:

Update proxy certificate validation so that certificates that assert
NON_REPUDIATION or KEY_CERTSIGN are accepted.

Result:

RFC-3820 compliant proxies that assert KeyUsage should now be accepted.

Closes jglobus/JGlobus#160

This patch is part of the latest OSG/WLCG package build.