### PR TITLE
Adapt to changes in PrivateKeyInfo class

### DIFF
--- a/ssl-proxies/src/main/java/org/globus/gsi/bc/BouncyCastleOpenSSLKey.java
+++ b/ssl-proxies/src/main/java/org/globus/gsi/bc/BouncyCastleOpenSSLKey.java
@@ -152,8 +152,8 @@ public class BouncyCastleOpenSSLKey extends OpenSSLKey {
 			try {
 				ASN1Primitive keyInfo = BouncyCastleUtil.toASN1Primitive(key
 						.getEncoded());
-				PrivateKeyInfo pkey = new PrivateKeyInfo((ASN1Sequence) keyInfo);
-				ASN1Primitive derKey = pkey.getPrivateKey();
+				PrivateKeyInfo pkey = PrivateKeyInfo.getInstance(keyInfo);
+				ASN1Primitive derKey = pkey.parsePrivateKey().toASN1Primitive();
 				return BouncyCastleUtil.toByteArray(derKey);
 			} catch (IOException e) {
 				// that should never happen


### PR DESCRIPTION
This PR adapts to changes in bouncycastle 1.61 (now in Fedora 30).
- The PrivateKeyInfo(ASN1Sequence) constructor in now declared private and can not be used.
- The PrivateKeyInfo.getPrivateKey() method has been removed (was previously deprecated).

I tried to update the code to still do the same thing, but please review.
It still compiles against bc 1.58 and 1.60, as well as now also compiling against bc 1.61.
