### PR TITLE
ASN1OutputStream constructor is private - use create() method

### DIFF
--- a/ssl-proxies/src/main/java/org/globus/gsi/bc/BouncyCastleUtil.java
+++ b/ssl-proxies/src/main/java/org/globus/gsi/bc/BouncyCastleUtil.java
@@ -78,7 +78,7 @@ public class BouncyCastleUtil {
     public static byte[] toByteArray(ASN1Primitive obj)
 	throws IOException {
 	ByteArrayOutputStream bout = new ByteArrayOutputStream();
-	ASN1OutputStream der = new ASN1OutputStream(bout);
+	ASN1OutputStream der = ASN1OutputStream.create(bout);
 	der.writeObject(obj);
 	return bout.toByteArray();
     }

--- a/ssl-proxies/src/main/java/org/globus/gsi/util/CertificateIOUtil.java
+++ b/ssl-proxies/src/main/java/org/globus/gsi/util/CertificateIOUtil.java
@@ -106,7 +106,7 @@ public final class CertificateIOUtil {
 
     public static byte[] encodePrincipal(X509Name subject) throws IOException {
         ByteArrayOutputStream bout = new ByteArrayOutputStream();
-        ASN1OutputStream der = new ASN1OutputStream(bout);
+        ASN1OutputStream der = ASN1OutputStream.create(bout);
         der.writeObject(subject.toASN1Primitive());
         return bout.toByteArray();
     }

--- a/ssl-proxies/src/test/java/org/globus/gsi/proxy/ext/ProxyCertInfoTest.java
+++ b/ssl-proxies/src/test/java/org/globus/gsi/proxy/ext/ProxyCertInfoTest.java
@@ -56,7 +56,7 @@ public class ProxyCertInfoTest extends TestCase {
 
 
 	ByteArrayOutputStream bOut = new ByteArrayOutputStream();
-        ASN1OutputStream dOut = new ASN1OutputStream(bOut);
+	ASN1OutputStream dOut = ASN1OutputStream.create(bOut);
 	dOut.writeObject(info);
 
 	ByteArrayInputStream bIn =
@@ -105,7 +105,7 @@ public class ProxyCertInfoTest extends TestCase {
 	assertEquals(testOid, info.getProxyPolicy().getPolicyLanguage());
 
 	ByteArrayOutputStream bOut = new ByteArrayOutputStream();
-        ASN1OutputStream dOut = new ASN1OutputStream(bOut);
+	ASN1OutputStream dOut = ASN1OutputStream.create(bOut);
 	dOut.writeObject(info);
 
 	ByteArrayInputStream bIn =


### PR DESCRIPTION
Bouncycastle was updated to version 1.70 in Fedora.
A few changes to JGlobus are needed to compile against this version.