### PR TITLE
DERTaggedObject.getObject() was removed - use .getInstance() instead

### DIFF
--- a/ssl-proxies/src/main/java/org/globus/gsi/proxy/ext/ProxyPolicy.java
+++ b/ssl-proxies/src/main/java/org/globus/gsi/proxy/ext/ProxyPolicy.java
@@ -60,7 +60,7 @@ public class ProxyPolicy implements ASN1Encodable {
         if (seq.size() > 1) {
             ASN1Encodable obj = seq.getObjectAt(1);
             if (obj instanceof DERTaggedObject) {
-                obj = ((DERTaggedObject) obj).getObject();
+                obj = DERTaggedObject.getInstance(obj);
             }
             this.policy = (DEROctetString) obj;
         }


### PR DESCRIPTION
Debian updated bouncycastle to version 1.77. Some changes needed.